### PR TITLE
Use black to format the code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+  - id: black
+    language_version: python3.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,16 @@ around pull request reviews, this project has adopted the
 be run against any new code written for this project. The advantage is, you
 no longer have to think about how your code is styled; it's all handled for you!
 
+To make this easier on you, you can [set up most editors][black-editors] to
+auto-run `black` for you. You can also use `pre-commit` to automagically run
+`black` for you before every commit! For this, you just need to run the following
+once:
+
+```sh
+$ pipenv run pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+
 ## Running the Tests
 
 Tests should be run using [tox](https://pypi.python.org/pypi/tox), so that we
@@ -76,3 +86,5 @@ to look at using [pyenv](https://github.com/pyenv/pyenv).
 **Note:** If you are using OS X and installed `pyenv` with brew, make sure to
 follow [these instructions](https://github.com/pyenv/pyenv#homebrew-on-macos)
 as well.
+
+[black-editors]: https://github.com/psf/black#editor-integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+## Setting Up Your Development Environment
+
+You should use a virtualenv for working on this project, as that will keep all
+installed packages isolated, without interfering with any global packages. To
+create a virtualenv and install all necessary dependencies, simply run the
+following commands:
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements-test.txt
+```
+
+## Branching
+
+If you would like to contribute to this project, you will need to use
+[git flow](https://github.com/nvie/gitflow). This way, any and all changes
+happen on the development branch and not on the master branch. As such, after
+you have git-flow-ified your `zoomus` git repo, create a pull request for your
+branch, and we'll take it from there.
+
+## Code Formatting
+
+To make code formatting easy on developers, and to simplify the conversation
+around pull request reviews, this project has adopted the
+[black](https://pypi.org/project/black/) code formatter. This formatter must
+be run against any new code written for this project. The advantage is, you
+no longer have to think about how your code is styled; it's all handled for you!
+
+## Running the Tests
+
+Tests should be run using [tox](https://pypi.python.org/pypi/tox), so that we
+can ensure they are run the same way, in a similar isolated environment, every
+time. Running this is as simple as one single command:
+
+```sh
+tox
+```
+
+Assuming all goes well, you should see a result akin to
+
+```sh
+  py27: commands succeeded
+  py34: commands succeeded
+  py35: commands succeeded
+  py36: commands succeeded
+  py37: commands succeeded
+  pypy: commands succeeded
+  pypy3: commands succeeded
+  congratulations :)
+```
+
+### Multiple Python Versions
+
+It is highly recommended, although not absolutely necessary, that you run the tests
+against all of our configured Python versions. This will help ensure that no
+unexpected errors come up in our CI process which might delay your changes from
+being merged.
+
+These versions are currently:
+
+* 2.7
+* 3.4
+* 3.5
+* 3.6
+* 3.7
+* pypy2
+* pypy3
+
+For an easy way to install and manage all of the Python versions, you may want
+to look at using [pyenv](https://github.com/pyenv/pyenv).
+
+**Note:** If you are using OS X and installed `pyenv` with brew, make sure to
+follow [these instructions](https://github.com/pyenv/pyenv#homebrew-on-macos)
+as well.

--- a/README.md
+++ b/README.md
@@ -112,58 +112,6 @@ Then run the tests via nose
 nosetests
 ```
 
-### Running the tests across multiple python versions in parallel
-
-If you don't trust our [Travis CI](https://travis-ci.org/actmd/zoomus) badge above, you can run all of the tests across multiple python versions by using [pyenv](https://github.com/yyuu/pyenv), and [tox](https://pypi.python.org/pypi/tox).
-
-Note: If you are using OS X and installed `pyenv` with brew, make sure to follow [these instructions](https://github.com/pyenv/pyenv#homebrew-on-macos) as well.
-
-You'll want to make sure that you have all of the different python versions are installed so that they can be tested:
-
-```sh
-# Install the versions
-pyenv install 2.7.10
-pyenv install 3.4.3
-pyenv install 3.5.0
-pyenv install 3.6.0
-pyenv install 3.7.0
-
-# Set all these to be global versions
-pyenv global system 2.7.10 3.4.3 3.5.0 3.6.0 3.7.0
-
-# Make sure that they are all there (they should all have a * next to them)
-pyenv versions
-```
-
-Once your Python interpreters are installed, you need set up a virtualenv and install tox.
-
-```sh
-python -m venv .venv
-source .venv/bin/activate
-pip install tox
-```
-
-Now that everything is installed and set up, you just need one command to run all of the tests against all of our defined Python versions:
-
-```sh
-tox
-```
-
-Assuming all goes well, you should see a result akin to
-
-```sh
-  py27: commands succeeded
-  py34: commands succeeded
-  py35: commands succeeded
-  py36: commands succeeded
-  py37: commands succeeded
-  pypy: commands succeeded
-  pypy3: commands succeeded
-  congratulations :)
-```
-
-If you run in to an issue with running detox, make sure that you have the latest version of `pip` as there are [some issues](https://github.com/yyuu/pyenv/issues/531) with `pyenv` and older versions of `pip`.
-
 ## Contributing
 
-If you would like to contribute to this project, you will need to use [git flow](https://github.com/nvie/gitflow). This way, any and all changes happen on the development branch and not on the master branch. As such, after you have git-flow-ified your `zoomus` git repo, create a pull request for your branch, and we'll take it from there.
+Please see the [CONTRIBUTING.md](./CONTRIBUTING.md) for the contribution guidelines for this project.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ with ZoomClient('API_KEY', 'API_SECRET') as client:
 * client.webinar.end(...)
 * client.webinar.register(...)
 
-
 ## Running the Tests
 
 ### Simple
@@ -115,9 +114,9 @@ nosetests
 
 ### Running the tests across multiple python versions in parallel
 
-If you don't trust our [Travis CI](https://travis-ci.org/actmd/zoomus) badge above, you can run all of the tests across multiple python versions by using [pyenv](https://github.com/yyuu/pyenv) and [detox](https://pypi.python.org/pypi/detox). A good writeup for what one needs to do to set this up can be found [here](http://blog.pinaxproject.com/2015/12/08/how-test-against-multiple-python-versions-parallel/).
+If you don't trust our [Travis CI](https://travis-ci.org/actmd/zoomus) badge above, you can run all of the tests across multiple python versions by using [pyenv](https://github.com/yyuu/pyenv), and [tox](https://pypi.python.org/pypi/tox).
 
-Note: If you are using OS X and installed `pyenv` with brew, make sure to follow [these instructions](https://github.com/yyuu/pyenv#homebrew-on-mac-os-x) as well.
+Note: If you are using OS X and installed `pyenv` with brew, make sure to follow [these instructions](https://github.com/pyenv/pyenv#homebrew-on-macos) as well.
 
 You'll want to make sure that you have all of the different python versions are installed so that they can be tested:
 
@@ -136,30 +135,31 @@ pyenv global system 2.7.10 3.4.3 3.5.0 3.6.0 3.7.0
 pyenv versions
 ```
 
-Once you get everything installed, you can run the tests across the different versions as follows.
+Once your Python interpreters are installed, you need set up a virtualenv and install tox.
 
 ```sh
-detox
+python -m venv .venv
+source .venv/bin/activate
+pip install tox
 ```
 
-Note this assumes that you have detox installed globally.
+Now that everything is installed and set up, you just need one command to run all of the tests against all of our defined Python versions:
+
+```sh
+tox
+```
 
 Assuming all goes well, you should see a result akin to
 
 ```sh
-py27-1.7: commands succeeded
-py27-1.8: commands succeeded
-py27-1.9: commands succeeded
-py27-master: commands succeeded
-py34-1.7: commands succeeded
-py34-1.8: commands succeeded
-py34-1.9: commands succeeded
-py34-master: commands succeeded
-py35-1.8: commands succeeded
-py35-1.9: commands succeeded
-py35-master: commands succeeded
-...
-congratulations :)
+  py27: commands succeeded
+  py34: commands succeeded
+  py35: commands succeeded
+  py36: commands succeeded
+  py37: commands succeeded
+  pypy: commands succeeded
+  pypy3: commands succeeded
+  congratulations :)
 ```
 
 If you run in to an issue with running detox, make sure that you have the latest version of `pip` as there are [some issues](https://github.com/yyuu/pyenv/issues/531) with `pyenv` and older versions of `pip`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-zoomus
-==========
+# zoomus
+
 [![Build Status](https://travis-ci.org/actmd/zoomus.svg?branch=master)](https://travis-ci.org/actmd/zoomus)
 
 [https://github.com/actmd/zoomus](https://github.com/actmd/zoomus)
@@ -8,8 +8,7 @@ Python wrapper around the [Zoom.us](http://zoom.us) REST API v1 and v2.
 
 This work is heavily inspired by the Ruby GEM of the same name, [Zoomus](https://github.com/mllocs/zoomus)
 
-Installation
-------------
+## Installation
 
 ### The easy way
 
@@ -17,13 +16,11 @@ Installation
 pip install zoomus
 ```
 
-Compatibility
--------------
+## Compatibility
 
 `zoomus` has been tested for Python 2.7, 3.4, 3.5, 3.6, 3.7, and pypy using [Travis CI](https://travis-ci.org/actmd/zoomus)
 
-Example Usage
--------------
+## Example Usage
 
 ### Create the client v2 (default)
 
@@ -71,9 +68,7 @@ with ZoomClient('API_KEY', 'API_SECRET') as client:
     ...
 ```
 
-
-Available methods
------------------
+## Available methods
 
 * client.user.create(...)
 * client.user.cust_create(...)
@@ -102,8 +97,7 @@ Available methods
 * client.webinar.register(...)
 
 
-Running the Tests
------------------
+## Running the Tests
 
 ### Simple
 
@@ -170,7 +164,6 @@ congratulations :)
 
 If you run in to an issue with running detox, make sure that you have the latest version of `pip` as there are [some issues](https://github.com/yyuu/pyenv/issues/531) with `pyenv` and older versions of `pip`.
 
-Contributing
-------------
+## Contributing
 
 If you would like to contribute to this project, you will need to use [git flow](https://github.com/nvie/gitflow). This way, any and all changes happen on the development branch and not on the master branch. As such, after you have git-flow-ified your `zoomus` git repo, create a pull request for your branch, and we'll take it from there.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # zoomus
 
-[![Build Status](https://travis-ci.org/actmd/zoomus.svg?branch=master)](https://travis-ci.org/actmd/zoomus)
+[![Build Status](https://img.shields.io/travis/actmd/zoomus)](https://travis-ci.org/actmd/zoomus)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/zoomus)](https://pypi.org/project/zoomus/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/zoomus)](https://pypi.org/project/zoomus/)
+[![PyPI Version](https://img.shields.io/pypi/v/zoomus)](https://pypi.org/project/zoomus/)
+[![PyPI License](https://img.shields.io/pypi/l/zoomus)](https://pypi.org/project/zoomus/)
+[![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black/)
 
 [https://github.com/actmd/zoomus](https://github.com/actmd/zoomus)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = [
+    "setuptools >= 40.6.2",
+    "wheel >= 0.30.0",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+target-version = ['py27', 'py34', 'py35', 'py36', 'py37']
+exclude = '''
+/(
+    \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | build
+    | dist
+)/
+'''

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,6 @@
 -r requirements.txt
 coverage==4.5.3
-mock==2.0.0
+mock==2.0.0; python_version < "3.0"
 nose==1.3.7
+tox==3.14.0
+black==19.3b0; python_version >= "3.6"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,3 +4,4 @@ mock==2.0.0; python_version < "3.0"
 nose==1.3.7
 tox==3.14.0
 black==19.3b0; python_version >= "3.6"
+pre-commit==1.18.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag = True
 
 [bumpversion:file:zoomus/__init__.py]
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [flake8]

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,12 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Development Status :: 5 - Production/Stable",
         "Natural Language :: English",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 def read(file_paths, default=""):
     # intentionally *not* adding an encoding option to open
     try:
-        with codecs.open(os.path.join(here, *file_paths), 'r') as fh:
+        with codecs.open(os.path.join(here, *file_paths), "r") as fh:
             return fh.read()
     except Exception:
         return default
@@ -19,43 +19,42 @@ def read(file_paths, default=""):
 
 def find_version(file_paths):
     version_file = read(file_paths)
-    version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
 
-description = 'Python client library for Zoom.us REST API v1 and v2'
-long_description = read('README.md', default=description)
+description = "Python client library for Zoom.us REST API v1 and v2"
+long_description = read("README.md", default=description)
 
 setup(
-    name='zoomus',
-    version=find_version(['zoomus', '__init__.py']),
-    url='https://github.com/actmd/zoomus',
-    license='Apache Software License',
-    author='Zoomus Contributors',
-    install_requires=['requests', 'PyJWT'],
-    author_email='zoomus@googlegroups.com',
+    name="zoomus",
+    version=find_version(["zoomus", "__init__.py"]),
+    url="https://github.com/actmd/zoomus",
+    license="Apache Software License",
+    author="Zoomus Contributors",
+    install_requires=["requests", "PyJWT"],
+    author_email="zoomus@googlegroups.com",
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    packages=['zoomus', 'zoomus.components'],
+    long_description_content_type="text/markdown",
+    packages=["zoomus", "zoomus.components"],
     include_package_data=True,
-    platforms='any',
+    platforms="any",
     zip_safe=False,
     classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
-        'Development Status :: 5 - Production/Stable',
-        'Natural Language :: English',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Topic :: Internet',
-        'Topic :: Office/Business',
-        'Topic :: Software Development :: Libraries'
-    ]
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Development Status :: 5 - Production/Stable",
+        "Natural Language :: English",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Topic :: Internet",
+        "Topic :: Office/Business",
+        "Topic :: Software Development :: Libraries",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 def read(file_paths, default=""):
     # intentionally *not* adding an encoding option to open
     try:
-        return codecs.open(os.path.join(here, *file_paths), 'r').read()
+        with codecs.open(os.path.join(here, *file_paths), 'r') as fh:
+            return fh.read()
     except Exception:
         return default
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import (
-    absolute_import,
-    unicode_literals)
+from __future__ import absolute_import, unicode_literals

--- a/tests/zoomus/components/meeting/test_create.py
+++ b/tests/zoomus/components/meeting/test_create.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,29 +17,21 @@ def suite():
 
 
 class CreateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_create(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.create(host_id='ID', topic='TOPIC', type='TYPE')
+            self.component.create(host_id="ID", topic="TOPIC", type="TYPE")
 
             mock_post_request.assert_called_with(
                 "/meeting/create",
-                params={
-                    'host_id': 'ID',
-                    'topic': 'TOPIC',
-                    'type': 'TYPE'
-                }
+                params={"host_id": "ID", "topic": "TOPIC", "type": "TYPE"},
             )
 
     def test_requires_host_id(self):
@@ -50,73 +40,59 @@ class CreateV1TestCase(unittest.TestCase):
 
     def test_requires_topic(self):
         with self.assertRaisesRegexp(ValueError, "'topic' must be set"):
-            self.component.create(host_id='ID')
+            self.component.create(host_id="ID")
 
     def test_requires_type(self):
         with self.assertRaisesRegexp(ValueError, "'type' must be set"):
-            self.component.create(host_id='ID', topic='TOPIC')
+            self.component.create(host_id="ID", topic="TOPIC")
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
         start_time = datetime.datetime.utcnow()
         self.component.create(
-            host_id='ID', topic='TOPIC', type='TYPE',
-            start_time=start_time)
+            host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
+        )
 
         mock_post_request.assert_called_with(
             "/meeting/create",
             params={
-                'host_id': 'ID',
-                'topic': 'TOPIC',
-                'type': 'TYPE',
-                'start_time': util.date_to_str(start_time)
-            }
+                "host_id": "ID",
+                "topic": "TOPIC",
+                "type": "TYPE",
+                "start_time": util.date_to_str(start_time),
+            },
         )
 
 
 class CreateV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_create(self, mock_post_request):
-        self.component.create(user_id='ID', topic='TOPIC', type='TYPE')
+        self.component.create(user_id="ID", topic="TOPIC", type="TYPE")
 
         mock_post_request.assert_called_with(
             "/users/ID/meetings",
-            params={
-                'user_id': 'ID',
-                'topic': 'TOPIC',
-                'type': 'TYPE'
-            }
+            params={"user_id": "ID", "topic": "TOPIC", "type": "TYPE"},
         )
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
             self.component.create()
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
         start_time = datetime.datetime.utcnow()
-        self.component.create(
-            user_id='ID',
-            start_time=start_time)
+        self.component.create(user_id="ID", start_time=start_time)
 
         mock_post_request.assert_called_with(
             "/users/ID/meetings",
-            params={
-                'user_id': 'ID',
-                'start_time': util.date_to_str(start_time)
-            }
+            params={"user_id": "ID", "start_time": util.date_to_str(start_time)},
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/meeting/test_create.py
+++ b/tests/zoomus/components/meeting/test_create.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/meeting/test_delete.py
+++ b/tests/zoomus/components/meeting/test_delete.py
@@ -16,68 +16,48 @@ def suite():
 
 
 class DeleteV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_delete(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.delete(id='ID', host_id='ID')
+            self.component.delete(id="ID", host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/meeting/delete",
-                params={
-                    'id': 'ID',
-                    'host_id': 'ID'
-                }
+                "/meeting/delete", params={"id": "ID", "host_id": "ID"}
             )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.delete()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
-            self.component.delete(id='ID')
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.component.delete(id="ID")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
 
 class DeleteV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'delete_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
     def test_can_delete(self, mock_delete_request):
-        self.component.delete(id='ID')
-        mock_delete_request.assert_called_with(
-            "/meetings/ID",
-            params={
-                'id': 'ID',
-            }
-        )
+        self.component.delete(id="ID")
+        mock_delete_request.assert_called_with("/meetings/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.delete()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/meeting/test_delete.py
+++ b/tests/zoomus/components/meeting/test_delete.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/meeting/test_end.py
+++ b/tests/zoomus/components/meeting/test_end.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/meeting/test_end.py
+++ b/tests/zoomus/components/meeting/test_end.py
@@ -16,42 +16,32 @@ def suite():
 
 
 class EndV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_end(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.end(id='ID', host_id='ID')
+            self.component.end(id="ID", host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/meeting/end",
-                params={
-                    'id': 'ID',
-                    'host_id': 'ID'
-                }
+                "/meeting/end", params={"id": "ID", "host_id": "ID"}
             )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.end()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
-            self.component.end(id='ID')
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.component.end(id="ID")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/meeting/test_get.py
+++ b/tests/zoomus/components/meeting/test_get.py
@@ -16,63 +16,48 @@ def suite():
 
 
 class GetV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.get(id='ID', host_id='ID')
+            self.component.get(id="ID", host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/meeting/get",
-                params={
-                    'id': 'ID',
-                    'host_id': 'ID'
-                }
+                "/meeting/get", params={"id": "ID", "host_id": "ID"}
             )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.get()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
-            self.component.get(id='ID')
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.component.get(id="ID")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
 
 class GetV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_get(self, mock_get_request):
-        self.component.get(id='ID')
-        mock_get_request.assert_called_with("/meetings/ID", params={'id': 'ID'})
+        self.component.get(id="ID")
+        mock_get_request.assert_called_with("/meetings/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.get()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/meeting/test_get.py
+++ b/tests/zoomus/components/meeting/test_get.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/meeting/test_list.py
+++ b/tests/zoomus/components/meeting/test_list.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,76 +17,61 @@ def suite():
 
 
 class ListV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_list(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.list(host_id='ID')
+            self.component.list(host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/meeting/list",
-                params={
-                    'host_id': 'ID'
-                }
+                "/meeting/list", params={"host_id": "ID"}
             )
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.list()
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
     def test_does_convert_startime_to_str_if_datetime(self):
 
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow()
             self.component.list(
-                host_id='ID', topic='TOPIC', type='TYPE',
-                start_time=start_time)
+                host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
+            )
 
             mock_post_request.assert_called_with(
                 "/meeting/list",
                 params={
-                    'host_id': 'ID',
-                    'topic': 'TOPIC',
-                    'type': 'TYPE',
-                    'start_time': util.date_to_str(start_time)
-                }
+                    "host_id": "ID",
+                    "topic": "TOPIC",
+                    "type": "TYPE",
+                    "start_time": util.date_to_str(start_time),
+                },
             )
 
 
 class ListV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_list(self, mock_get_request):
-        self.component.list(user_id='ID')
+        self.component.list(user_id="ID")
 
         mock_get_request.assert_called_with(
-            "/users/ID/meetings",
-            params={
-                'user_id': 'ID'
-            }
+            "/users/ID/meetings", params={"user_id": "ID"}
         )
 
     def test_requires_user_id(self):
@@ -96,5 +79,5 @@ class ListV2TestCase(unittest.TestCase):
             self.component.list()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/meeting/test_list.py
+++ b/tests/zoomus/components/meeting/test_list.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/meeting/test_update.py
+++ b/tests/zoomus/components/meeting/test_update.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/meeting/test_update.py
+++ b/tests/zoomus/components/meeting/test_update.py
@@ -17,95 +17,67 @@ def suite():
 
 
 class UpdateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_update(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.update(id='ID', host_id='ID')
+            self.component.update(id="ID", host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/meeting/update",
-                params={
-                    'id': 'ID',
-                    'host_id': 'ID'
-                }
+                "/meeting/update", params={"id": "ID", "host_id": "ID"}
             )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.update()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
-            self.component.update(id='ID')
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.component.update(id="ID")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_start_time_gets_transformed(self, mock_post_request):
-        self.component.update(id='ID', host_id='ID', start_time=datetime(1969, 1, 1))
+        self.component.update(id="ID", host_id="ID", start_time=datetime(1969, 1, 1))
         mock_post_request.assert_called_with(
             "/meeting/update",
-            params={
-                'id': 'ID',
-                'host_id': 'ID',
-                'start_time': '1969-01-01T00:00:00Z'
-            }
+            params={"id": "ID", "host_id": "ID", "start_time": "1969-01-01T00:00:00Z"},
         )
 
 
 class UpdateV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'patch_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
     def test_can_update(self, mock_post_request):
-        self.component.update(id='42', foo='bar')
+        self.component.update(id="42", foo="bar")
 
         mock_post_request.assert_called_with(
-            "/meetings/42",
-            params={
-                'id': '42',
-                'foo': 'bar'
-            }
+            "/meetings/42", params={"id": "42", "foo": "bar"}
         )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.update()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
-    @patch.object(components.base.BaseComponent, 'patch_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
     def test_start_time_gets_transformed(self, mock_patch_request):
-        self.component.update(id='42', start_time=datetime(1969, 1, 1))
+        self.component.update(id="42", start_time=datetime(1969, 1, 1))
         mock_patch_request.assert_called_with(
-            "/meetings/42",
-            params={
-                'id': '42',
-                'start_time': '1969-01-01T00:00:00Z'
-            }
+            "/meetings/42", params={"id": "42", "start_time": "1969-01-01T00:00:00Z"}
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/recording/test_delete.py
+++ b/tests/zoomus/components/recording/test_delete.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/recording/test_delete.py
+++ b/tests/zoomus/components/recording/test_delete.py
@@ -16,55 +16,39 @@ def suite():
 
 
 class DeleteV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.recording.RecordingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_delete(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.delete(meeting_id='ID')
+            self.component.delete(meeting_id="ID")
 
             mock_post_request.assert_called_with(
-                "/recording/delete",
-                params={
-                    'meeting_id': 'ID'
-                }
+                "/recording/delete", params={"meeting_id": "ID"}
             )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.delete()
-            self.assertEqual(
-                context.exception.message, "'meeting_id' must be set")
+            self.assertEqual(context.exception.message, "'meeting_id' must be set")
 
 
 class DeleteV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.recording.RecordingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'delete_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
     def test_can_delete(self, mock_delete_request):
-        self.component.delete(meeting_id='ID')
+        self.component.delete(meeting_id="ID")
         mock_delete_request.assert_called_with(
-            "/meetings/ID/recordings",
-            params={
-                'meeting_id': 'ID'
-            }
+            "/meetings/ID/recordings", params={"meeting_id": "ID"}
         )
 
     def test_requires_id(self):
@@ -72,5 +56,5 @@ class DeleteV2TestCase(unittest.TestCase):
             self.component.delete()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/recording/test_get.py
+++ b/tests/zoomus/components/recording/test_get.py
@@ -16,55 +16,39 @@ def suite():
 
 
 class GetV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.recording.RecordingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.get(meeting_id='ID')
+            self.component.get(meeting_id="ID")
 
             mock_post_request.assert_called_with(
-                "/recording/get",
-                params={
-                    'meeting_id': 'ID'
-                }
+                "/recording/get", params={"meeting_id": "ID"}
             )
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.get()
-            self.assertEqual(
-                context.exception.message, "'meeting_id' must be set")
+            self.assertEqual(context.exception.message, "'meeting_id' must be set")
 
 
 class GetV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.recording.RecordingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_get(self, mock_get_request):
-        self.component.get(meeting_id='ID')
+        self.component.get(meeting_id="ID")
         mock_get_request.assert_called_with(
-            "/meetings/ID/recordings",
-            params={
-                'meeting_id': 'ID'
-            }
+            "/meetings/ID/recordings", params={"meeting_id": "ID"}
         )
 
     def test_requires_id(self):
@@ -72,5 +56,5 @@ class GetV2TestCase(unittest.TestCase):
             self.component.get()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/recording/test_get.py
+++ b/tests/zoomus/components/recording/test_get.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/recording/test_list.py
+++ b/tests/zoomus/components/recording/test_list.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/recording/test_list.py
+++ b/tests/zoomus/components/recording/test_list.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,104 +17,85 @@ def suite():
 
 
 class ListV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.recording.RecordingComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_list(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.list(host_id='ID')
+            self.component.list(host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/recording/list",
-                params={
-                    'host_id': 'ID'
-                }
+                "/recording/list", params={"host_id": "ID"}
             )
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.list()
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
     def test_does_convert_startime_to_str_if_datetime(self):
 
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow() - datetime.timedelta(days=10)
             end_time = datetime.datetime.utcnow()
             self.component.list(
-                host_id='ID',
-                start=start_time,
-                end=end_time,
-                meeting_number="111")
+                host_id="ID", start=start_time, end=end_time, meeting_number="111"
+            )
 
             mock_post_request.assert_called_with(
                 "/recording/list",
                 params={
-                    'host_id': 'ID',
-                    'from': util.date_to_str(start_time),
-                    'to': util.date_to_str(end_time),
-                    "meeting_number": "111"
-                }
+                    "host_id": "ID",
+                    "from": util.date_to_str(start_time),
+                    "to": util.date_to_str(end_time),
+                    "meeting_number": "111",
+                },
             )
 
 
 class ListV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.recording.RecordingComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_list(self, mock_get_request):
-        self.component.list(user_id='ID')
+        self.component.list(user_id="ID")
         mock_get_request.assert_called_with(
-            "/users/ID/recordings",
-            params={
-                'user_id': 'ID'
-            }
+            "/users/ID/recordings", params={"user_id": "ID"}
         )
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
             self.component.list()
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_does_convert_startime_to_str_if_datetime(self, mock_get_request):
         start_time = datetime.datetime.utcnow() - datetime.timedelta(days=10)
         end_time = datetime.datetime.utcnow()
         self.component.list(
-            user_id='ID',
-            start=start_time,
-            end=end_time,
-            meeting_number="111")
+            user_id="ID", start=start_time, end=end_time, meeting_number="111"
+        )
 
         mock_get_request.assert_called_with(
             "/users/ID/recordings",
             params={
-                'user_id': 'ID',
-                'from': util.date_to_str(start_time),
-                'to': util.date_to_str(end_time),
-                "meeting_number": "111"
-            }
+                "user_id": "ID",
+                "from": util.date_to_str(start_time),
+                "to": util.date_to_str(end_time),
+                "meeting_number": "111",
+            },
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/report/test_get_account_report.py
+++ b/tests/zoomus/components/report/test_get_account_report.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/report/test_get_account_report.py
+++ b/tests/zoomus/components/report/test_get_account_report.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,89 +17,76 @@ def suite():
 
 
 class GetAccountReportV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.report.ReportComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get_account_report(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow()
             end_time = datetime.datetime.utcnow()
-            self.component.get_account_report(
-                start_time=start_time, end_time=end_time)
+            self.component.get_account_report(start_time=start_time, end_time=end_time)
 
             mock_post_request.assert_called_with(
                 "/report/getaccountreport",
                 params={
-                    'from': util.date_to_str(start_time),
-                    'to': util.date_to_str(end_time)
-                }
+                    "from": util.date_to_str(start_time),
+                    "to": util.date_to_str(end_time),
+                },
             )
 
     def test_requires_start_time(self):
         with self.assertRaises(ValueError) as context:
             self.component.get_account_report()
-            self.assertEqual(
-                context.exception.message, "'start_time' must be set")
+            self.assertEqual(context.exception.message, "'start_time' must be set")
 
     def test_requires_end_time(self):
         with self.assertRaises(ValueError) as context:
             self.component.get_account_report(start_time=datetime.datetime.utcnow())
-            self.assertEqual(
-                context.exception.message, "'end_time' must be set")
+            self.assertEqual(context.exception.message, "'end_time' must be set")
 
     def test_does_convert_start_time_to_str_if_datetime(self):
 
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow()
             end_time = datetime.datetime.utcnow()
 
-            self.component.get_account_report(
-                start_time=start_time, end_time=end_time)
+            self.component.get_account_report(start_time=start_time, end_time=end_time)
 
             mock_post_request.assert_called_with(
                 "/report/getaccountreport",
                 params={
-                    'from': util.date_to_str(start_time),
-                    'to': util.date_to_str(end_time)
-                }
+                    "from": util.date_to_str(start_time),
+                    "to": util.date_to_str(end_time),
+                },
             )
 
 
 class GetAccountReportV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.report.ReportComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_get_account_report(self, mock_get_request):
         start_time = datetime.datetime.utcnow()
         end_time = datetime.datetime.utcnow()
-        self.component.get_account_report(
-            start_time=start_time, end_time=end_time)
+        self.component.get_account_report(start_time=start_time, end_time=end_time)
 
         mock_get_request.assert_called_with(
             "/report/users",
             params={
-                'from': util.date_to_str(start_time),
-                'to': util.date_to_str(end_time)
-            }
+                "from": util.date_to_str(start_time),
+                "to": util.date_to_str(end_time),
+            },
         )
 
     def test_requires_start_time(self):
@@ -112,22 +97,21 @@ class GetAccountReportV2TestCase(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
             self.component.get_account_report(start_time=datetime.datetime.utcnow())
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_does_convert_start_time_to_str_if_datetime(self, mock_get_request):
         start_time = datetime.datetime.utcnow()
         end_time = datetime.datetime.utcnow()
 
-        self.component.get_account_report(
-            start_time=start_time, end_time=end_time)
+        self.component.get_account_report(start_time=start_time, end_time=end_time)
 
         mock_get_request.assert_called_with(
             "/report/users",
             params={
-                'from': util.date_to_str(start_time),
-                'to': util.date_to_str(end_time)
-            }
+                "from": util.date_to_str(start_time),
+                "to": util.date_to_str(end_time),
+            },
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/report/test_get_user_report.py
+++ b/tests/zoomus/components/report/test_get_user_report.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,90 +17,79 @@ def suite():
 
 
 class GetUserReportV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.report.ReportComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get_user_report(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow()
             end_time = datetime.datetime.utcnow()
-            self.component.get_user_report(
-                start_time=start_time, end_time=end_time)
+            self.component.get_user_report(start_time=start_time, end_time=end_time)
 
             mock_post_request.assert_called_with(
                 "/report/getuserreport",
                 params={
-                    'from': util.date_to_str(start_time),
-                    'to': util.date_to_str(end_time)
-                }
+                    "from": util.date_to_str(start_time),
+                    "to": util.date_to_str(end_time),
+                },
             )
 
     def test_requires_start_time(self):
         with self.assertRaises(ValueError) as context:
             self.component.get_user_report()
-            self.assertEqual(
-                context.exception.message, "'start_time' must be set")
+            self.assertEqual(context.exception.message, "'start_time' must be set")
 
     def test_requires_end_time(self):
         with self.assertRaises(ValueError) as context:
             self.component.get_user_report(start_time=datetime.datetime.utcnow())
-            self.assertEqual(
-                context.exception.message, "'end_time' must be set")
+            self.assertEqual(context.exception.message, "'end_time' must be set")
 
     def test_does_convert_start_time_to_str_if_datetime(self):
 
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow()
             end_time = datetime.datetime.utcnow()
 
-            self.component.get_user_report(
-                start_time=start_time, end_time=end_time)
+            self.component.get_user_report(start_time=start_time, end_time=end_time)
 
             mock_post_request.assert_called_with(
                 "/report/getuserreport",
                 params={
-                    'from': util.date_to_str(start_time),
-                    'to': util.date_to_str(end_time)
-                }
+                    "from": util.date_to_str(start_time),
+                    "to": util.date_to_str(end_time),
+                },
             )
 
 
 class GetUserReportV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.report.ReportComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_get_user_report(self, mock_get_request):
         start_time = datetime.datetime.utcnow()
         end_time = datetime.datetime.utcnow()
         self.component.get_user_report(
-            user_id='ID', start_time=start_time, end_time=end_time)
+            user_id="ID", start_time=start_time, end_time=end_time
+        )
 
         mock_get_request.assert_called_with(
             "/report/users/ID/meetings",
             params={
-                'user_id': 'ID',
-                'from': util.date_to_str(start_time),
-                'to': util.date_to_str(end_time)
-            }
+                "user_id": "ID",
+                "from": util.date_to_str(start_time),
+                "to": util.date_to_str(end_time),
+            },
         )
 
     def test_requires_user_id(self):
@@ -111,29 +98,32 @@ class GetUserReportV2TestCase(unittest.TestCase):
 
     def test_requires_start_time(self):
         with self.assertRaisesRegexp(ValueError, "'start_time' must be set"):
-            self.component.get_user_report(user_id='ID')
+            self.component.get_user_report(user_id="ID")
 
     def test_requires_end_time(self):
         with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
-            self.component.get_user_report(user_id='ID', start_time=datetime.datetime.utcnow())
+            self.component.get_user_report(
+                user_id="ID", start_time=datetime.datetime.utcnow()
+            )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_does_convert_start_time_to_str_if_datetime(self, mock_get_request):
         start_time = datetime.datetime.utcnow()
         end_time = datetime.datetime.utcnow()
 
         self.component.get_user_report(
-            user_id='ID', start_time=start_time, end_time=end_time)
+            user_id="ID", start_time=start_time, end_time=end_time
+        )
 
         mock_get_request.assert_called_with(
             "/report/users/ID/meetings",
             params={
-                'user_id': 'ID',
-                'from': util.date_to_str(start_time),
-                'to': util.date_to_str(end_time)
-            }
+                "user_id": "ID",
+                "from": util.date_to_str(start_time),
+                "to": util.date_to_str(end_time),
+            },
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/report/test_get_user_report.py
+++ b/tests/zoomus/components/report/test_get_user_report.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/test_base.py
+++ b/tests/zoomus/components/test_base.py
@@ -1,4 +1,5 @@
 import unittest
+
 try:
     from unittest import mock
 except ImportError:
@@ -14,45 +15,45 @@ def suite():
     return suite
 
 
-@mock.patch('zoomus.components.base.util.ApiClient.post_request')
+@mock.patch("zoomus.components.base.util.ApiClient.post_request")
 class BaseComponentTestCase(unittest.TestCase):
-
-    def test_post_request_includes_config_details_in_data_when_no_data(self, mock_post_request):
+    def test_post_request_includes_config_details_in_data_when_no_data(
+        self, mock_post_request
+    ):
         component = components.base.BaseComponent(
             base_uri="http://www.foo.com",
-            config={'api_key': 'KEY', 'api_secret': 'SECRET', 'version': API_VERSION_1})
+            config={"api_key": "KEY", "api_secret": "SECRET", "version": API_VERSION_1},
+        )
         component.post_request("foo")
         mock_post_request.assert_called_with(
-            "foo",
-            params=component.config,
-            data=None,
-            headers=None,
-            cookies=None
+            "foo", params=component.config, data=None, headers=None, cookies=None
         )
 
-    def test_post_request_includes_config_details_in_data_when_there_is_data(self, mock_post_request):
+    def test_post_request_includes_config_details_in_data_when_there_is_data(
+        self, mock_post_request
+    ):
         component = components.base.BaseComponent(
             base_uri="http://www.foo.com",
-            config={'api_key': 'KEY', 'api_secret': 'SECRET', 'version': API_VERSION_1})
-        component.post_request("foo", params={'foo': 'bar'})
+            config={"api_key": "KEY", "api_secret": "SECRET", "version": API_VERSION_1},
+        )
+        component.post_request("foo", params={"foo": "bar"})
 
-        params = {'foo': 'bar'}
+        params = {"foo": "bar"}
         params.update(component.config)
 
         mock_post_request.assert_called_with(
-            "foo",
-            params=params,
-            data=None,
-            headers=None,
-            cookies=None
+            "foo", params=params, data=None, headers=None, cookies=None
         )
 
     def test_v2_post_request_passes_jwt_token(self, mock_post_request):
         component = components.base.BaseComponent(
             base_uri="http://www.foo.com",
             config={
-                'api_key': 'KEY', 'api_secret': 'SECRET', 'version': API_VERSION_2, 'token': 42
-            }
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": API_VERSION_2,
+                "token": 42,
+            },
         )
         component.post_request("foo")
         mock_post_request.assert_called_with(
@@ -60,9 +61,9 @@ class BaseComponentTestCase(unittest.TestCase):
             params={},
             data=None,
             headers={"Authorization": "Bearer 42"},
-            cookies=None
+            cookies=None,
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_create.py
+++ b/tests/zoomus/components/user/test_create.py
@@ -16,47 +16,32 @@ def suite():
 
 
 class CreateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_create(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             self.component.create()
 
-            mock_post_request.assert_called_with(
-                "/user/create",
-                params={}
-            )
+            mock_post_request.assert_called_with("/user/create", params={})
 
 
 class CreateV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_create(self, mock_post_request):
         self.component.create(foo="bar")
-        mock_post_request.assert_called_with(
-            "/users",
-            params={'foo': 'bar'}
-        )
+        mock_post_request.assert_called_with("/users", params={"foo": "bar"})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_create.py
+++ b/tests/zoomus/components/user/test_create.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_cust_create.py
+++ b/tests/zoomus/components/user/test_cust_create.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_cust_create.py
+++ b/tests/zoomus/components/user/test_cust_create.py
@@ -16,42 +16,32 @@ def suite():
 
 
 class CustCreateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get_by_email(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.cust_create(type='foo', email='a@b.com')
+            self.component.cust_create(type="foo", email="a@b.com")
 
             mock_post_request.assert_called_with(
-                "/user/custcreate",
-                params={
-                    'type': 'foo',
-                    'email': 'a@b.com'
-                }
+                "/user/custcreate", params={"type": "foo", "email": "a@b.com"}
             )
 
     def test_requires_type(self):
         with self.assertRaises(ValueError) as context:
             self.component.cust_create()
-            self.assertEqual(
-                context.exception.message, "'type' must be set")
+            self.assertEqual(context.exception.message, "'type' must be set")
 
     def test_requires_email(self):
         with self.assertRaises(ValueError) as context:
             self.component.cust_create()
-            self.assertEqual(
-                context.exception.message, "'email' must be set")
+            self.assertEqual(context.exception.message, "'email' must be set")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_delete.py
+++ b/tests/zoomus/components/user/test_delete.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_delete.py
+++ b/tests/zoomus/components/user/test_delete.py
@@ -16,61 +16,41 @@ def suite():
 
 
 class DeleteV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_delete(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.delete(id='ID')
+            self.component.delete(id="ID")
 
-            mock_post_request.assert_called_with(
-                "/user/delete",
-                params={
-                    'id': 'ID'
-                }
-            )
+            mock_post_request.assert_called_with("/user/delete", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.delete()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
 
 class DeleteV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'delete_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
     def test_can_delete(self, mock_delete_request):
-        self.component.delete(id='ID')
-        mock_delete_request.assert_called_with(
-            "/users/ID",
-            params={
-                'id': 'ID'
-            }
-        )
+        self.component.delete(id="ID")
+        mock_delete_request.assert_called_with("/users/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.delete()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_get.py
+++ b/tests/zoomus/components/user/test_get.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_get.py
+++ b/tests/zoomus/components/user/test_get.py
@@ -16,28 +16,19 @@ def suite():
 
 
 class GetV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.get(id='ID')
+            self.component.get(id="ID")
 
-            mock_post_request.assert_called_with(
-                "/user/get",
-                params={
-                    'id': 'ID',
-                }
-            )
+            mock_post_request.assert_called_with("/user/get", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -45,30 +36,20 @@ class GetV1TestCase(unittest.TestCase):
 
 
 class GetV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_get(self, mock_get_request):
-        self.component.get(id='ID')
-        mock_get_request.assert_called_with(
-            "/users/ID",
-            params={
-                'id': 'ID',
-            }
-        )
+        self.component.get(id="ID")
+        mock_get_request.assert_called_with("/users/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.get()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_get_by_email.py
+++ b/tests/zoomus/components/user/test_get_by_email.py
@@ -16,42 +16,32 @@ def suite():
 
 
 class GetByEmailV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_get_by_email(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.get_by_email(email='a@b.com', login_type='foo')
+            self.component.get_by_email(email="a@b.com", login_type="foo")
 
             mock_post_request.assert_called_with(
-                "/user/getbyemail",
-                params={
-                    'email': 'a@b.com',
-                    'login_type': 'foo'
-                }
+                "/user/getbyemail", params={"email": "a@b.com", "login_type": "foo"}
             )
 
     def test_requires_email(self):
         with self.assertRaises(ValueError) as context:
             self.component.get_by_email()
-            self.assertEqual(
-                context.exception.message, "'email' must be set")
+            self.assertEqual(context.exception.message, "'email' must be set")
 
     def test_requires_login_type(self):
         with self.assertRaises(ValueError) as context:
             self.component.get_by_email()
-            self.assertEqual(
-                context.exception.message, "'login_type' must be set")
+            self.assertEqual(context.exception.message, "'login_type' must be set")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_get_by_email.py
+++ b/tests/zoomus/components/user/test_get_by_email.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_list.py
+++ b/tests/zoomus/components/user/test_list.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_list.py
+++ b/tests/zoomus/components/user/test_list.py
@@ -16,48 +16,33 @@ def suite():
 
 
 class ListV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_list(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             self.component.list()
 
-            mock_post_request.assert_called_with(
-                "/user/list",
-                params={}
-            )
+            mock_post_request.assert_called_with("/user/list", params={})
 
 
 class ListV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_list(self, mock_get_request):
         self.component.list()
 
-        mock_get_request.assert_called_with(
-            "/users",
-            params={}
-        )
+        mock_get_request.assert_called_with("/users", params={})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_pending.py
+++ b/tests/zoomus/components/user/test_pending.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_pending.py
+++ b/tests/zoomus/components/user/test_pending.py
@@ -16,27 +16,20 @@ def suite():
 
 
 class PendingV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_end(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             self.component.pending()
 
-            mock_post_request.assert_called_with(
-                "/user/pending",
-                params={}
-            )
+            mock_post_request.assert_called_with("/user/pending", params={})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/user/test_update.py
+++ b/tests/zoomus/components/user/test_update.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/user/test_update.py
+++ b/tests/zoomus/components/user/test_update.py
@@ -16,61 +16,41 @@ def suite():
 
 
 class UpdateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_update(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.update(id='ID')
+            self.component.update(id="ID")
 
-            mock_post_request.assert_called_with(
-                "/user/update",
-                params={
-                    'id': 'ID'
-                }
-            )
+            mock_post_request.assert_called_with("/user/update", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.update()
-            self.assertEqual(
-                context.exception.message, "'id' must be set")
+            self.assertEqual(context.exception.message, "'id' must be set")
 
 
 class UpdateV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'patch_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
     def test_can_update(self, mock_patch_request):
-        self.component.update(id='ID')
-        mock_patch_request.assert_called_with(
-            "/users/ID",
-            params={
-                'id': 'ID'
-            }
-        )
+        self.component.update(id="ID")
+        mock_patch_request.assert_called_with("/users/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.update()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_create.py
+++ b/tests/zoomus/components/webinar/test_create.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,26 +17,17 @@ def suite():
 
 
 class CreateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_create(self, mock_post_request):
-        self.component.create(host_id='ID', topic='TOPIC')
+        self.component.create(host_id="ID", topic="TOPIC")
 
         mock_post_request.assert_called_with(
-            "/webinar/create",
-            params={
-                'host_id': 'ID',
-                'topic': 'TOPIC'
-            }
+            "/webinar/create", params={"host_id": "ID", "topic": "TOPIC"}
         )
 
     def test_requires_host_id(self):
@@ -47,44 +36,35 @@ class CreateV1TestCase(unittest.TestCase):
 
     def test_requires_topic(self):
         with self.assertRaisesRegexp(ValueError, "'topic' must be set"):
-            self.component.create(host_id='ID')
+            self.component.create(host_id="ID")
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
         start_time = datetime.datetime.utcnow()
-        self.component.create(
-            host_id='ID', topic='TOPIC', start_time=start_time)
+        self.component.create(host_id="ID", topic="TOPIC", start_time=start_time)
 
         mock_post_request.assert_called_with(
             "/webinar/create",
             params={
-                'host_id': 'ID',
-                'topic': 'TOPIC',
-                'start_time': util.date_to_str(start_time)
-            }
+                "host_id": "ID",
+                "topic": "TOPIC",
+                "start_time": util.date_to_str(start_time),
+            },
         )
 
 
 class CreateV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_create(self, mock_post_request):
-        self.component.create(user_id='ID')
+        self.component.create(user_id="ID")
 
         mock_post_request.assert_called_with(
-            "/users/ID/webinars",
-            params={
-                'user_id': 'ID',
-            }
+            "/users/ID/webinars", params={"user_id": "ID"}
         )
 
     def test_requires_user_id(self):
@@ -92,5 +72,5 @@ class CreateV2TestCase(unittest.TestCase):
             self.component.create()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_create.py
+++ b/tests/zoomus/components/webinar/test_create.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/webinar/test_delete.py
+++ b/tests/zoomus/components/webinar/test_delete.py
@@ -16,26 +16,17 @@ def suite():
 
 
 class DeleteV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_delete(self, mock_post_request):
-        self.component.delete(id='ID', host_id='ID')
+        self.component.delete(id="ID", host_id="ID")
 
         mock_post_request.assert_called_with(
-            "/webinar/delete",
-            params={
-                'id': 'ID',
-                'host_id': 'ID'
-            }
+            "/webinar/delete", params={"id": "ID", "host_id": "ID"}
         )
 
     def test_requires_id(self):
@@ -44,35 +35,25 @@ class DeleteV1TestCase(unittest.TestCase):
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
-            self.component.delete(id='ID')
+            self.component.delete(id="ID")
 
 
 class DeleteV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'delete_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
     def test_can_delete(self, mock_delete_request):
-        self.component.delete(id='ID')
+        self.component.delete(id="ID")
 
-        mock_delete_request.assert_called_with(
-            "/webinars/ID",
-            params={
-                'id': 'ID',
-            }
-        )
+        mock_delete_request.assert_called_with("/webinars/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.delete()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_delete.py
+++ b/tests/zoomus/components/webinar/test_delete.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/webinar/test_end.py
+++ b/tests/zoomus/components/webinar/test_end.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/webinar/test_end.py
+++ b/tests/zoomus/components/webinar/test_end.py
@@ -16,26 +16,17 @@ def suite():
 
 
 class EndV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_end(self, mock_post_request):
-        self.component.end(id='ID', host_id='ID')
+        self.component.end(id="ID", host_id="ID")
 
         mock_post_request.assert_called_with(
-            "/webinar/end",
-            params={
-                'id': 'ID',
-                'host_id': 'ID'
-            }
+            "/webinar/end", params={"id": "ID", "host_id": "ID"}
         )
 
     def test_requires_id(self):
@@ -44,29 +35,21 @@ class EndV1TestCase(unittest.TestCase):
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
-            self.component.end(id='ID')
+            self.component.end(id="ID")
 
 
 class EndV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'put_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "put_request", return_value=True)
     def test_can_end(self, mock_put_request):
-        self.component.end(id='ID')
+        self.component.end(id="ID")
 
         mock_put_request.assert_called_with(
-            "/webinars/ID/status",
-            params={
-                'status': 'end'
-            }
+            "/webinars/ID/status", params={"status": "end"}
         )
 
     def test_requires_id(self):
@@ -74,5 +57,5 @@ class EndV2TestCase(unittest.TestCase):
             self.component.end()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_get.py
+++ b/tests/zoomus/components/webinar/test_get.py
@@ -16,26 +16,17 @@ def suite():
 
 
 class GetV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_end(self, mock_post_request):
-        self.component.get(id='ID', host_id='ID')
+        self.component.get(id="ID", host_id="ID")
 
         mock_post_request.assert_called_with(
-            "/webinar/get",
-            params={
-                'id': 'ID',
-                'host_id': 'ID'
-            }
+            "/webinar/get", params={"id": "ID", "host_id": "ID"}
         )
 
     def test_requires_id(self):
@@ -44,35 +35,25 @@ class GetV1TestCase(unittest.TestCase):
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
-            self.component.get(id='ID')
+            self.component.get(id="ID")
 
 
 class GetV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_end(self, mock_get_request):
-        self.component.get(id='ID')
+        self.component.get(id="ID")
 
-        mock_get_request.assert_called_with(
-            "/webinars/ID",
-            params={
-                'id': 'ID',
-            }
-        )
+        mock_get_request.assert_called_with("/webinars/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.get()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_get.py
+++ b/tests/zoomus/components/webinar/test_get.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/webinar/test_list.py
+++ b/tests/zoomus/components/webinar/test_list.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,69 +17,51 @@ def suite():
 
 
 class ListV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_list(self, mock_post_request):
-        self.component.list(host_id='ID')
+        self.component.list(host_id="ID")
 
-        mock_post_request.assert_called_with(
-            "/webinar/list",
-            params={
-                'host_id': 'ID'
-            }
-        )
+        mock_post_request.assert_called_with("/webinar/list", params={"host_id": "ID"})
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.list()
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
         start_time = datetime.datetime.utcnow()
         self.component.list(
-            host_id='ID', topic='TOPIC', type='TYPE',
-            start_time=start_time)
+            host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
+        )
 
         mock_post_request.assert_called_with(
             "/webinar/list",
             params={
-                'host_id': 'ID',
-                'topic': 'TOPIC',
-                'type': 'TYPE',
-                'start_time': util.date_to_str(start_time)
-            }
+                "host_id": "ID",
+                "topic": "TOPIC",
+                "type": "TYPE",
+                "start_time": util.date_to_str(start_time),
+            },
         )
 
 
 class ListV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'get_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
     def test_can_list(self, mock_get_request):
-        self.component.list(user_id='ID')
+        self.component.list(user_id="ID")
 
         mock_get_request.assert_called_with(
-            "/users/ID/webinars",
-            params={
-                'user_id': 'ID'
-            }
+            "/users/ID/webinars", params={"user_id": "ID"}
         )
 
     def test_requires_user_id(self):
@@ -89,5 +69,5 @@ class ListV2TestCase(unittest.TestCase):
             self.component.list()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_list.py
+++ b/tests/zoomus/components/webinar/test_list.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/webinar/test_register.py
+++ b/tests/zoomus/components/webinar/test_register.py
@@ -17,32 +17,25 @@ def suite():
 
 
 class RegisterV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_register(self, mock_post_request):
         self.component.register(
-            id='ID',
-            email='foo@bar.com',
-            first_name="Foo",
-            last_name="Bar")
+            id="ID", email="foo@bar.com", first_name="Foo", last_name="Bar"
+        )
 
         mock_post_request.assert_called_with(
             "/webinar/register",
             params={
-                'id': 'ID',
-                'email': 'foo@bar.com',
-                'first_name': 'Foo',
-                'last_name': 'Bar'
-            }
+                "id": "ID",
+                "email": "foo@bar.com",
+                "first_name": "Foo",
+                "last_name": "Bar",
+            },
         )
 
     def test_requires_id(self):
@@ -51,62 +44,57 @@ class RegisterV1TestCase(unittest.TestCase):
 
     def test_requires_email(self):
         with self.assertRaisesRegexp(ValueError, "'email' must be set"):
-            self.component.register(id='ID')
+            self.component.register(id="ID")
 
     def test_requires_first_name(self):
         with self.assertRaisesRegexp(ValueError, "'first_name' must be set"):
-            self.component.register(id='ID', email='foo@bar.com')
+            self.component.register(id="ID", email="foo@bar.com")
 
     def test_requires_last_name(self):
         with self.assertRaisesRegexp(ValueError, "'last_name' must be set"):
-            self.component.register(
-                id='ID', email='foo@bar.com', first_name='foo')
+            self.component.register(id="ID", email="foo@bar.com", first_name="foo")
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_start_time_gets_transformed(self, mock_post_request):
         self.component.register(
-            id='ID', email='foo@bar.com', first_name='foo', last_name='bar',
-            start_time=datetime(1969, 1, 1)
+            id="ID",
+            email="foo@bar.com",
+            first_name="foo",
+            last_name="bar",
+            start_time=datetime(1969, 1, 1),
         )
         mock_post_request.assert_called_with(
             "/webinar/register",
             params={
-                'id': 'ID',
-                'email': 'foo@bar.com',
-                'first_name': 'foo',
-                'last_name': 'bar',
-                'start_time': '1969-01-01T00:00:00Z',
-            }
+                "id": "ID",
+                "email": "foo@bar.com",
+                "first_name": "foo",
+                "last_name": "bar",
+                "start_time": "1969-01-01T00:00:00Z",
+            },
         )
 
 
 class RegisterV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_register(self, mock_post_request):
         self.component.register(
-            id='ID',
-            email='foo@bar.com',
-            first_name="Foo",
-            last_name="Bar")
+            id="ID", email="foo@bar.com", first_name="Foo", last_name="Bar"
+        )
 
         mock_post_request.assert_called_with(
             "/webinars/ID/registrants",
             params={
-                'id': 'ID',
-                'email': 'foo@bar.com',
-                'first_name': 'Foo',
-                'last_name': 'Bar'
-            }
+                "id": "ID",
+                "email": "foo@bar.com",
+                "first_name": "Foo",
+                "last_name": "Bar",
+            },
         )
 
     def test_requires_id(self):
@@ -115,17 +103,16 @@ class RegisterV2TestCase(unittest.TestCase):
 
     def test_requires_email(self):
         with self.assertRaisesRegexp(ValueError, "'email' must be set"):
-            self.component.register(id='ID')
+            self.component.register(id="ID")
 
     def test_requires_first_name(self):
         with self.assertRaisesRegexp(ValueError, "'first_name' must be set"):
-            self.component.register(id='ID', email='foo@bar.com')
+            self.component.register(id="ID", email="foo@bar.com")
 
     def test_requires_last_name(self):
         with self.assertRaisesRegexp(ValueError, "'last_name' must be set"):
-            self.component.register(
-                id='ID', email='foo@bar.com', first_name='foo')
+            self.component.register(id="ID", email="foo@bar.com", first_name="foo")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_register.py
+++ b/tests/zoomus/components/webinar/test_register.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/webinar/test_upcoming.py
+++ b/tests/zoomus/components/webinar/test_upcoming.py
@@ -6,9 +6,7 @@ try:
 except ImportError:
     from mock import patch
 
-from zoomus import (
-    components,
-    util)
+from zoomus import components, util
 
 
 def suite():
@@ -19,55 +17,48 @@ def suite():
 
 
 class UpcomingV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
     def test_can_upcoming(self):
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
-            self.component.upcoming(host_id='ID')
+            self.component.upcoming(host_id="ID")
 
             mock_post_request.assert_called_with(
-                "/webinar/list/registration",
-                params={
-                    'host_id': 'ID'
-                }
+                "/webinar/list/registration", params={"host_id": "ID"}
             )
 
     def test_requires_host_id(self):
         with self.assertRaises(ValueError) as context:
             self.component.upcoming()
-            self.assertEqual(
-                context.exception.message, "'host_id' must be set")
+            self.assertEqual(context.exception.message, "'host_id' must be set")
 
     def test_does_convert_startime_to_str_if_datetime(self):
 
-        with patch.object(components.base.BaseComponent, 'post_request',
-                          return_value=True) as mock_post_request:
+        with patch.object(
+            components.base.BaseComponent, "post_request", return_value=True
+        ) as mock_post_request:
 
             start_time = datetime.datetime.utcnow()
             self.component.upcoming(
-                host_id='ID', topic='TOPIC', type='TYPE',
-                start_time=start_time)
+                host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
+            )
 
             mock_post_request.assert_called_with(
                 "/webinar/list/registration",
                 params={
-                    'host_id': 'ID',
-                    'topic': 'TOPIC',
-                    'type': 'TYPE',
-                    'start_time': util.date_to_str(start_time)
-                }
+                    "host_id": "ID",
+                    "topic": "TOPIC",
+                    "type": "TYPE",
+                    "start_time": util.date_to_str(start_time),
+                },
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/webinar/test_upcoming.py
+++ b/tests/zoomus/components/webinar/test_upcoming.py
@@ -1,7 +1,10 @@
 import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import (
     components,

--- a/tests/zoomus/components/webinar/test_update.py
+++ b/tests/zoomus/components/webinar/test_update.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import components
 

--- a/tests/zoomus/components/webinar/test_update.py
+++ b/tests/zoomus/components/webinar/test_update.py
@@ -17,26 +17,17 @@ def suite():
 
 
 class UpdateV1TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_can_update(self, mock_post_request):
-        self.component.update(id='ID', host_id='ID')
+        self.component.update(id="ID", host_id="ID")
 
         mock_post_request.assert_called_with(
-            "/webinar/update",
-            params={
-                'id': 'ID',
-                'host_id': 'ID'
-            }
+            "/webinar/update", params={"id": "ID", "host_id": "ID"}
         )
 
     def test_requires_id(self):
@@ -45,47 +36,37 @@ class UpdateV1TestCase(unittest.TestCase):
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
-            self.component.update(id='ID')
+            self.component.update(id="ID")
 
-    @patch.object(components.base.BaseComponent, 'post_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
     def test_start_time_gets_transformed(self, mock_post_request):
-        self.component.update(id='42', host_id='HOST', start_time=datetime(1969, 1, 1))
+        self.component.update(id="42", host_id="HOST", start_time=datetime(1969, 1, 1))
         mock_post_request.assert_called_with(
             "/webinar/update",
             params={
-                'id': '42',
-                'host_id': 'HOST',
-                'start_time': '1969-01-01T00:00:00Z',
-            }
+                "id": "42",
+                "host_id": "HOST",
+                "start_time": "1969-01-01T00:00:00Z",
+            },
         )
 
 
 class UpdateV2TestCase(unittest.TestCase):
-
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com",
-            config={
-                'api_key': 'KEY',
-                'api_secret': 'SECRET'
-            }
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, 'patch_request', return_value=True)
+    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
     def test_can_update(self, mock_patch_request):
-        self.component.update(id='ID')
+        self.component.update(id="ID")
 
-        mock_patch_request.assert_called_with(
-            "/webinars/ID",
-            params={
-                'id': 'ID',
-            }
-        )
+        mock_patch_request.assert_called_with("/webinars/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.update()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/test_client.py
+++ b/tests/zoomus/test_client.py
@@ -1,4 +1,5 @@
 import unittest
+
 try:
     from unittest import mock
 except ImportError:

--- a/tests/zoomus/test_client.py
+++ b/tests/zoomus/test_client.py
@@ -16,132 +16,111 @@ def suite():
 
 
 class ZoomClientTestCase(unittest.TestCase):
-
     def test_init_sets_config(self):
-        client = ZoomClient('KEY', 'SECRET')
+        client = ZoomClient("KEY", "SECRET")
         self.assertEqual(
             client.config,
             {
-                'api_key': 'KEY',
-                'api_secret': 'SECRET',
-                'data_type': 'json',
-                'token': util.generate_jwt('KEY', 'SECRET'),
-                'version': API_VERSION_2,
-            }
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "data_type": "json",
+                "token": util.generate_jwt("KEY", "SECRET"),
+                "version": API_VERSION_2,
+            },
         )
 
     def test_invalid_api_version_raises_error(self):
         with self.assertRaisesRegexp(RuntimeError, "API version not supported: 42"):
-            ZoomClient('KEY', 'SECRET', version=42)
+            ZoomClient("KEY", "SECRET", version=42)
 
     def test_init_sets_config_with_timeout(self):
-        client = ZoomClient('KEY', 'SECRET', timeout=500)
+        client = ZoomClient("KEY", "SECRET", timeout=500)
         self.assertEqual(client.timeout, 500)
 
     def test_cannot_init_with_non_int_timeout(self):
         with self.assertRaises(ValueError) as context:
-            ZoomClient('KEY', 'SECRET', timeout='bad')
+            ZoomClient("KEY", "SECRET", timeout="bad")
             self.assertEqual(
-                context.exception.message, "timeout value must be an integer")
+                context.exception.message, "timeout value must be an integer"
+            )
 
     def test_init_creates_all_components(self):
-        client = ZoomClient('KEY', 'SECRET')
+        client = ZoomClient("KEY", "SECRET")
         self.assertEqual(
-            set(['meeting', 'report', 'user', 'webinar', 'recording']),
-            set(client.components.keys())
+            set(["meeting", "report", "user", "webinar", "recording"]),
+            set(client.components.keys()),
         )
         self.assertIsInstance(
-            client.components['meeting'],
-            components.meeting.MeetingComponentV2
+            client.components["meeting"], components.meeting.MeetingComponentV2
         )
         self.assertIsInstance(
-            client.components['report'],
-            components.report.ReportComponentV2
+            client.components["report"], components.report.ReportComponentV2
         )
         self.assertIsInstance(
-            client.components['user'],
-            components.user.UserComponentV2
+            client.components["user"], components.user.UserComponentV2
         )
         self.assertIsInstance(
-            client.components['webinar'],
-            components.webinar.WebinarComponentV2
+            client.components["webinar"], components.webinar.WebinarComponentV2
         )
         self.assertIsInstance(
-            client.components['recording'],
-            components.recording.RecordingComponentV2
+            client.components["recording"], components.recording.RecordingComponentV2
         )
 
     def test_api_version_defaults_to_2(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertEqual(client.config['version'], API_VERSION_2)
+        client = ZoomClient("KEY", "SECRET")
+        self.assertEqual(client.config["version"], API_VERSION_2)
 
     def test_can_get_api_key(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertEqual(client.api_key, 'KEY')
+        client = ZoomClient("KEY", "SECRET")
+        self.assertEqual(client.api_key, "KEY")
 
     def test_can_set_api_key(self):
-        client = ZoomClient('KEY', 'SECRET')
-        client.api_key = 'NEW-KEY'
-        self.assertEqual(client.api_key, 'NEW-KEY')
+        client = ZoomClient("KEY", "SECRET")
+        client.api_key = "NEW-KEY"
+        self.assertEqual(client.api_key, "NEW-KEY")
 
     def test_can_get_api_secret(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertEqual(client.api_secret, 'SECRET')
+        client = ZoomClient("KEY", "SECRET")
+        self.assertEqual(client.api_secret, "SECRET")
 
     def test_can_set_api_secret(self):
-        client = ZoomClient('KEY', 'SECRET')
-        client.api_secret = 'NEW-SECRET'
-        self.assertEqual(client.api_secret, 'NEW-SECRET')
+        client = ZoomClient("KEY", "SECRET")
+        client.api_secret = "NEW-SECRET"
+        self.assertEqual(client.api_secret, "NEW-SECRET")
 
     def test_can_get_meeting_component(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertIsInstance(
-            client.meeting,
-            components.meeting.MeetingComponentV2
-        )
+        client = ZoomClient("KEY", "SECRET")
+        self.assertIsInstance(client.meeting, components.meeting.MeetingComponentV2)
 
     def test_can_get_report_component(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertIsInstance(
-            client.report,
-            components.report.ReportComponentV2
-        )
+        client = ZoomClient("KEY", "SECRET")
+        self.assertIsInstance(client.report, components.report.ReportComponentV2)
 
     def test_can_get_user_component(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertIsInstance(
-            client.user,
-            components.user.UserComponentV2
-        )
+        client = ZoomClient("KEY", "SECRET")
+        self.assertIsInstance(client.user, components.user.UserComponentV2)
 
     def test_can_get_webinar_component(self):
-        client = ZoomClient('KEY', 'SECRET')
-        self.assertIsInstance(
-            client.webinar,
-            components.webinar.WebinarComponentV2
-        )
+        client = ZoomClient("KEY", "SECRET")
+        self.assertIsInstance(client.webinar, components.webinar.WebinarComponentV2)
 
     def test_can_get_recording_component(self):
-        client = ZoomClient('KEY', 'SECRET')
+        client = ZoomClient("KEY", "SECRET")
         self.assertIsInstance(
-            client.recording,
-            components.recording.RecordingComponentV2
+            client.recording, components.recording.RecordingComponentV2
         )
 
     def test_can_use_client_with_context(self):
-        with ZoomClient('KEY', 'SECRET') as client:
-            self.assertIsInstance(
-                client,
-                ZoomClient
-            )
+        with ZoomClient("KEY", "SECRET") as client:
+            self.assertIsInstance(client, ZoomClient)
 
-    @mock.patch('zoomus.client.util.generate_jwt')
+    @mock.patch("zoomus.client.util.generate_jwt")
     def test_refresh_token_replaces_config_token_with_new_jwt(self, mock_jwt):
-        client = ZoomClient('KEY', 'SECRET')
+        client = ZoomClient("KEY", "SECRET")
         client.refresh_token()
-        mock_jwt.assert_called_with('KEY', 'SECRET')
-        self.assertEqual(client.config['token'], (mock_jwt.return_value, ))
+        mock_jwt.assert_called_with("KEY", "SECRET")
+        self.assertEqual(client.config["token"], (mock_jwt.return_value,))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/test_util.py
+++ b/tests/zoomus/test_util.py
@@ -21,7 +21,6 @@ def suite():
 
 
 class ApiClientTestCase(unittest.TestCase):
-
     def test_init_sets_config(self):
         client = util.ApiClient(base_uri="http://www.foo.com")
         self.assertEqual(client.base_uri, "http://www.foo.com")
@@ -33,9 +32,10 @@ class ApiClientTestCase(unittest.TestCase):
 
     def test_cannot_init_with_non_int_timeout(self):
         with self.assertRaises(ValueError) as context:
-            util.ApiClient(base_uri="http://www.foo.com", timeout='bad')
+            util.ApiClient(base_uri="http://www.foo.com", timeout="bad")
             self.assertEqual(
-                context.exception.message, "timeout value must be an integer")
+                context.exception.message, "timeout value must be an integer"
+            )
 
     def test_can_get_base_uri(self):
         client = util.ApiClient(base_uri="http://www.foo.com")
@@ -63,431 +63,461 @@ class ApiClientTestCase(unittest.TestCase):
     def test_cannot_set_timeout_to_non_int(self):
         client = util.ApiClient(base_uri="http://www.foo.com")
         with self.assertRaises(ValueError) as context:
-            client.timeout = 'bad'
+            client.timeout = "bad"
             self.assertEqual(
-                context.exception.message, "timeout value must be an integer")
+                context.exception.message, "timeout value must be an integer"
+            )
 
     def test_url_for_returns_complete_url(self):
         client = util.ApiClient(base_uri="http://www.foo.com")
-        self.assertEqual(
-            client.url_for("bar"),
-            "http://www.foo.com/bar")
+        self.assertEqual(client.url_for("bar"), "http://www.foo.com/bar")
 
     def test_url_for_ignores_preceding_slash(self):
         client = util.ApiClient(base_uri="http://www.foo.com")
-        self.assertEqual(
-            client.url_for("/bar"),
-            "http://www.foo.com/bar")
+        self.assertEqual(client.url_for("/bar"), "http://www.foo.com/bar")
 
     def test_url_for_ignores_trailing_slash(self):
         client = util.ApiClient(base_uri="http://www.foo.com")
-        self.assertEqual(
-            client.url_for("bar/"),
-            "http://www.foo.com/bar")
+        self.assertEqual(client.url_for("bar/"), "http://www.foo.com/bar")
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_can_get_request(self, mocked_get):
 
         mocked_get.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.get_request('endpoint')
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.get_request("endpoint")
 
         mocked_get.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             headers=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_can_get_request_with_params(self, mocked_get):
 
         mocked_get.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.get_request('endpoint', params={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.get_request("endpoint", params={"foo": "bar"})
 
         mocked_get.assert_called_with(
-            client.url_for('endpoint'),
-            params={'foo': 'bar'},
+            client.url_for("endpoint"),
+            params={"foo": "bar"},
             headers=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_can_get_request_with_headers(self, mocked_get):
 
         mocked_get.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.get_request('endpoint', headers={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.get_request("endpoint", headers={"foo": "bar"})
 
         mocked_get.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            headers={'foo': 'bar'},
-            timeout=client.timeout
+            headers={"foo": "bar"},
+            timeout=client.timeout,
         )
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_can_post_request(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.post_request('endpoint')
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.post_request("endpoint")
 
         mocked_post.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_can_post_request_with_params(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.post_request('endpoint', params={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.post_request("endpoint", params={"foo": "bar"})
 
         mocked_post.assert_called_with(
-            client.url_for('endpoint'),
-            params={'foo': 'bar'},
+            client.url_for("endpoint"),
+            params={"foo": "bar"},
             data=None,
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_can_post_request_with_dict_data(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.post_request('endpoint', data={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.post_request("endpoint", data={"foo": "bar"})
 
         mocked_post.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            data=json.dumps({"foo": "bar"}),
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_can_post_request_with_json_data(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.post_request('endpoint', data=json.dumps({'foo': 'bar'}))
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.post_request("endpoint", data=json.dumps({"foo": "bar"}))
 
         mocked_post.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            data=json.dumps({"foo": "bar"}),
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_can_post_request_with_headers(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.post_request('endpoint', headers={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.post_request("endpoint", headers={"foo": "bar"})
 
         mocked_post.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
-            headers={'foo': 'bar'},
+            headers={"foo": "bar"},
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_can_post_request_with_cookies(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.post_request('endpoint', cookies={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.post_request("endpoint", cookies={"foo": "bar"})
 
         mocked_post.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
             headers=None,
-            cookies={'foo': 'bar'},
-            timeout=client.timeout
+            cookies={"foo": "bar"},
+            timeout=client.timeout,
         )
 
-    @patch('requests.patch')
+    @patch("requests.patch")
     def test_can_patch_request(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.patch_request('endpoint')
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.patch_request("endpoint")
 
         mocked_patch.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.patch')
+    @patch("requests.patch")
     def test_can_patch_request_with_params(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.patch_request('endpoint', params={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.patch_request("endpoint", params={"foo": "bar"})
 
         mocked_patch.assert_called_with(
-            client.url_for('endpoint'),
-            params={'foo': 'bar'},
+            client.url_for("endpoint"),
+            params={"foo": "bar"},
             data=None,
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.patch')
+    @patch("requests.patch")
     def test_can_patch_request_with_dict_data(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.patch_request('endpoint', data={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.patch_request("endpoint", data={"foo": "bar"})
 
         mocked_patch.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            data=json.dumps({"foo": "bar"}),
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.patch')
+    @patch("requests.patch")
     def test_can_patch_request_with_json_data(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.patch_request('endpoint', data=json.dumps({'foo': 'bar'}))
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.patch_request("endpoint", data=json.dumps({"foo": "bar"}))
 
         mocked_patch.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            data=json.dumps({"foo": "bar"}),
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.patch')
+    @patch("requests.patch")
     def test_can_patch_request_with_headers(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.patch_request('endpoint', headers={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.patch_request("endpoint", headers={"foo": "bar"})
 
         mocked_patch.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
-            headers={'foo': 'bar'},
+            headers={"foo": "bar"},
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.patch')
+    @patch("requests.patch")
     def test_can_patch_request_with_cookies(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.patch_request('endpoint', cookies={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.patch_request("endpoint", cookies={"foo": "bar"})
 
         mocked_patch.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
             headers=None,
-            cookies={'foo': 'bar'},
-            timeout=client.timeout
+            cookies={"foo": "bar"},
+            timeout=client.timeout,
         )
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_can_delete_request(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.delete_request('endpoint')
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.delete_request("endpoint")
 
         mocked_delete.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_can_delete_request_with_params(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.delete_request('endpoint', params={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.delete_request("endpoint", params={"foo": "bar"})
 
         mocked_delete.assert_called_with(
-            client.url_for('endpoint'),
-            params={'foo': 'bar'},
+            client.url_for("endpoint"),
+            params={"foo": "bar"},
             data=None,
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_can_delete_request_with_dict_data(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.delete_request('endpoint', data={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.delete_request("endpoint", data={"foo": "bar"})
 
         mocked_delete.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            data=json.dumps({"foo": "bar"}),
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_can_delete_request_with_json_data(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.delete_request('endpoint', data=json.dumps({'foo': 'bar'}))
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.delete_request("endpoint", data=json.dumps({"foo": "bar"}))
 
         mocked_delete.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
-            data=json.dumps({'foo': 'bar'}),
+            data=json.dumps({"foo": "bar"}),
             headers=None,
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_can_delete_request_with_headers(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.delete_request('endpoint', headers={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.delete_request("endpoint", headers={"foo": "bar"})
 
         mocked_delete.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
-            headers={'foo': 'bar'},
+            headers={"foo": "bar"},
             cookies=None,
-            timeout=client.timeout
+            timeout=client.timeout,
         )
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_can_delete_request_with_cookies(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
 
-        client = util.ApiClient(base_uri="http://www.foo.com", config={'version': API_VERSION_1})
-        client.delete_request('endpoint', cookies={'foo': 'bar'})
+        client = util.ApiClient(
+            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+        )
+        client.delete_request("endpoint", cookies={"foo": "bar"})
 
         mocked_delete.assert_called_with(
-            client.url_for('endpoint'),
+            client.url_for("endpoint"),
             params=None,
             data=None,
             headers=None,
-            cookies={'foo': 'bar'},
-            timeout=client.timeout
+            cookies={"foo": "bar"},
+            timeout=client.timeout,
         )
 
 
 class RequireKeysTestCase(unittest.TestCase):
-
     def test_can_require_keys_with_single_string_key(self):
-        d = {'a': 1}
+        d = {"a": 1}
         with self.assertRaises(ValueError) as context:
-            util.require_keys(d, 'b')
+            util.require_keys(d, "b")
             self.assertEqual(context.exception.message, "'b' must be set")
 
     def test_can_require_keys_with_list_keys(self):
-        d = {'a': 1}
+        d = {"a": 1}
         with self.assertRaises(ValueError) as context:
-            util.require_keys(d, ['b'])
+            util.require_keys(d, ["b"])
             self.assertEqual(context.exception.message, "'b' must be set")
 
     def test_can_require_keys_with_multi_item_list_keys(self):
-        d = {'a': 1, 'b': 2}
+        d = {"a": 1, "b": 2}
         with self.assertRaises(ValueError) as context:
-            util.require_keys(d, ['b', 'c'])
+            util.require_keys(d, ["b", "c"])
             self.assertEqual(context.exception.message, "'c' must be set")
 
     def test_require_keys_with_dict_raises_error_if_missing(self):
-        d = {'a': 1}
+        d = {"a": 1}
         with self.assertRaises(ValueError) as context:
-            util.require_keys(d, 'b')
+            util.require_keys(d, "b")
             self.assertEqual(context.exception.message, "'b' must be set")
 
     def test_require_keys_with_dict_does_not_raises_error_if_none_by_default(self):
-        d = {'a': 1, 'b': None}
-        self.assertTrue(util.require_keys(d, 'b'))
+        d = {"a": 1, "b": None}
+        self.assertTrue(util.require_keys(d, "b"))
 
     def test_require_keys_with_dict_does_raises_error_if_none_not_allowed(self):
-        d = {'a': 1, 'b': None}
+        d = {"a": 1, "b": None}
         with self.assertRaises(ValueError) as context:
-            self.assertTrue(util.require_keys(d, 'b', allow_none=False))
+            self.assertTrue(util.require_keys(d, "b", allow_none=False))
             self.assertEqual(context.exception.message, "'b' cannot be None")
 
 
 class DateToStrTestCase(unittest.TestCase):
-
     def test_can_convert_date_to_str(self):
         d = datetime.date(year=2015, month=12, day=8)
-        self.assertEqual(
-            util.date_to_str(d),
-            "2015-12-08T00:00:00Z")
+        self.assertEqual(util.date_to_str(d), "2015-12-08T00:00:00Z")
 
     def test_can_convert_datetime_to_str(self):
-        d = datetime.datetime(
-            year=2015, month=12, day=8, hour=23, minute=21, second=37)
-        self.assertEqual(
-            util.date_to_str(d),
-            "2015-12-08T23:21:37Z")
+        d = datetime.datetime(year=2015, month=12, day=8, hour=23, minute=21, second=37)
+        self.assertEqual(util.date_to_str(d), "2015-12-08T23:21:37Z")
 
 
 class IsStrTypeTestCase(unittest.TestCase):
@@ -495,22 +525,22 @@ class IsStrTypeTestCase(unittest.TestCase):
     from sys import version_info
 
     def test_str_is_str_type(self):
-        self.assertTrue(util.is_str_type('s'))
+        self.assertTrue(util.is_str_type("s"))
 
     def test_numeric_str_is_str_type(self):
-        self.assertTrue(util.is_str_type('5'))
+        self.assertTrue(util.is_str_type("5"))
 
     def test_non_str_is_not_str_type(self):
         self.assertFalse(util.is_str_type(5))
 
     @unittest.skipIf(version_info[0] >= 3, "No applicable to Python 3+")
     def test_unicode_is_str_type(self):
-        self.assertTrue(util.is_str_type(unicode('s')))
+        self.assertTrue(util.is_str_type(unicode("s")))
 
     @unittest.skipIf(version_info[0] >= 3, "No applicable to Python 3+")
     def test_numeric_unicode_is_str_type(self):
-        self.assertTrue(util.is_str_type(unicode('5')))
+        self.assertTrue(util.is_str_type(unicode("5")))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/test_util.py
+++ b/tests/zoomus/test_util.py
@@ -2,7 +2,10 @@ import datetime
 import json
 import unittest
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from zoomus import API_VERSION_1, util
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py{27,34,35,36,37,py,py3}
-skip_missing_interpreters=true
+skip_missing_interpreters = true
+isolated_build = true
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,py,py3}
+envlist = py{27,34,35,36,37,py,py3},black
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -9,3 +9,8 @@ deps =
 
 commands =
     nosetests {posargs}
+
+[testenv:black]
+basepython = python3.6
+deps = black==19.3b0
+commands = black --check .

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,7 @@ commands =
 basepython = python3.6
 deps = black==19.3b0
 commands = black --check .
+
+[travis]
+python =
+    3.6: py36, black

--- a/zoomus/__init__.py
+++ b/zoomus/__init__.py
@@ -6,5 +6,5 @@ from zoomus.client import ZoomClient
 from zoomus.util import API_VERSION_1, API_VERSION_2
 
 
-__all__ = ['API_VERSION_1', 'API_VERSION_2', 'ZoomClient']
-__version__ = '1.0.0'
+__all__ = ["API_VERSION_1", "API_VERSION_2", "ZoomClient"]
+__version__ = "1.0.0"

--- a/zoomus/client.py
+++ b/zoomus/client.py
@@ -7,25 +7,25 @@ from zoomus.util import API_VERSION_1, API_VERSION_2
 
 
 API_BASE_URIS = {
-    API_VERSION_1: 'https://api.zoom.us/v1',
-    API_VERSION_2: 'https://api.zoom.us/v2'
+    API_VERSION_1: "https://api.zoom.us/v1",
+    API_VERSION_2: "https://api.zoom.us/v2",
 }
 
 COMPONENT_CLASSES = {
     API_VERSION_1: {
-        'user': components.user.UserComponent,
-        'meeting': components.meeting.MeetingComponent,
-        'report': components.report.ReportComponent,
-        'webinar': components.webinar.WebinarComponent,
-        'recording': components.recording.RecordingComponent,
+        "user": components.user.UserComponent,
+        "meeting": components.meeting.MeetingComponent,
+        "report": components.report.ReportComponent,
+        "webinar": components.webinar.WebinarComponent,
+        "recording": components.recording.RecordingComponent,
     },
     API_VERSION_2: {
-        'user': components.user.UserComponentV2,
-        'meeting': components.meeting.MeetingComponentV2,
-        'report': components.report.ReportComponentV2,
-        'webinar': components.webinar.WebinarComponentV2,
-        'recording': components.recording.RecordingComponentV2,
-    }
+        "user": components.user.UserComponentV2,
+        "meeting": components.meeting.MeetingComponentV2,
+        "report": components.report.ReportComponentV2,
+        "webinar": components.webinar.WebinarComponentV2,
+        "recording": components.recording.RecordingComponentV2,
+    },
 }
 
 
@@ -34,7 +34,9 @@ class ZoomClient(util.ApiClient):
 
     """Base URL for Zoom API"""
 
-    def __init__(self, api_key, api_secret, data_type='json', timeout=15, version=API_VERSION_2):
+    def __init__(
+        self, api_key, api_secret, data_type="json", timeout=15, version=API_VERSION_2
+    ):
         """Create a new Zoom client
 
         :param api_key: The Zooom.us API key
@@ -52,16 +54,18 @@ class ZoomClient(util.ApiClient):
 
         # Setup the config details
         self.config = {
-            'api_key': api_key,
-            'api_secret': api_secret,
-            'data_type': data_type,
-            'version': version,
-            'token': util.generate_jwt(api_key, api_secret),
+            "api_key": api_key,
+            "api_secret": api_secret,
+            "data_type": data_type,
+            "version": version,
+            "token": util.generate_jwt(api_key, api_secret),
         }
 
         # Instantiate the components
         for key in self.components.keys():
-            self.components[key] = self.components[key](base_uri=BASE_URI, config=self.config)
+            self.components[key] = self.components[key](
+                base_uri=BASE_URI, config=self.config
+            )
 
     def __enter__(self):
         return self
@@ -70,53 +74,53 @@ class ZoomClient(util.ApiClient):
         return
 
     def refresh_token(self):
-        self.config['token'] = util.generate_jwt(
-            self.config['api_key'],
-            self.config['api_secret']),
+        self.config["token"] = (
+            util.generate_jwt(self.config["api_key"], self.config["api_secret"]),
+        )
 
     @property
     def api_key(self):
         """The Zoom.us api_key"""
-        return self.config.get('api_key')
+        return self.config.get("api_key")
 
     @api_key.setter
     def api_key(self, value):
         """Set the api_key"""
-        self.config['api_key'] = value
+        self.config["api_key"] = value
         self.refresh_token()
 
     @property
     def api_secret(self):
         """The Zoom.us api_secret"""
-        return self.config.get('api_secret')
+        return self.config.get("api_secret")
 
     @api_secret.setter
     def api_secret(self, value):
         """Set the api_secret"""
-        self.config['api_secret'] = value
+        self.config["api_secret"] = value
         self.refresh_token()
 
     @property
     def meeting(self):
         """Get the meeting component"""
-        return self.components.get('meeting')
+        return self.components.get("meeting")
 
     @property
     def report(self):
         """Get the report component"""
-        return self.components.get('report')
+        return self.components.get("report")
 
     @property
     def user(self):
         """Get the user component"""
-        return self.components.get('user')
+        return self.components.get("user")
 
     @property
     def webinar(self):
         """Get the webinar component"""
-        return self.components.get('webinar')
+        return self.components.get("webinar")
 
     @property
     def recording(self):
         """Get the recording component"""
-        return self.components.get('recording')
+        return self.components.get("recording")

--- a/zoomus/components/__init__.py
+++ b/zoomus/components/__init__.py
@@ -2,9 +2,4 @@
 
 from __future__ import absolute_import
 
-from . import (
-    meeting,
-    recording,
-    report,
-    user,
-    webinar)
+from . import meeting, recording, report, user, webinar

--- a/zoomus/components/base.py
+++ b/zoomus/components/base.py
@@ -18,10 +18,12 @@ class BaseComponent(util.ApiClient):
                            attributes to the ApiClient object.
         """
         super(BaseComponent, self).__init__(
-            base_uri=base_uri, timeout=timeout, config=config, **kwargs)
+            base_uri=base_uri, timeout=timeout, config=config, **kwargs
+        )
 
     def post_request(
-            self, endpoint, params=None, data=None, headers=None, cookies=None):
+        self, endpoint, params=None, data=None, headers=None, cookies=None
+    ):
         """Helper function for POST requests
 
         Since the Zoom.us API only uses POST requests and each post request
@@ -37,10 +39,10 @@ class BaseComponent(util.ApiClient):
         :return: The :class:``requests.Response`` object for this request
         """
         params = params or {}
-        if self.config['version'] == util.API_VERSION_1:
+        if self.config["version"] == util.API_VERSION_1:
             params.update(self.config)
-        if headers is None and self.config.get('version') == util.API_VERSION_2:
-            headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
+        if headers is None and self.config.get("version") == util.API_VERSION_2:
+            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
         return super(BaseComponent, self).post_request(
-            endpoint, params=params, data=data, headers=headers,
-            cookies=cookies)
+            endpoint, params=params, data=data, headers=headers, cookies=cookies
+        )

--- a/zoomus/components/meeting.py
+++ b/zoomus/components/meeting.py
@@ -10,68 +10,65 @@ class MeetingComponent(base.BaseComponent):
     """Component dealing with all meeting related matters"""
 
     def list(self, **kwargs):
-        util.require_keys(kwargs, 'host_id')
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, "host_id")
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/meeting/list", params=kwargs)
 
     def create(self, **kwargs):
-        util.require_keys(kwargs, ['host_id', 'topic', 'type'])
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, ["host_id", "topic", "type"])
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/meeting/create", params=kwargs)
 
     def update(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, ["id", "host_id"])
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/meeting/update", params=kwargs)
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
+        util.require_keys(kwargs, ["id", "host_id"])
         return self.post_request("/meeting/delete", params=kwargs)
 
     def end(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
+        util.require_keys(kwargs, ["id", "host_id"])
         return self.post_request("/meeting/end", params=kwargs)
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
+        util.require_keys(kwargs, ["id", "host_id"])
         return self.post_request("/meeting/get", params=kwargs)
 
 
 class MeetingComponentV2(base.BaseComponent):
-
     def list(self, **kwargs):
-        util.require_keys(kwargs, 'user_id')
+        util.require_keys(kwargs, "user_id")
         return self.get_request(
-            "/users/{}/meetings".format(kwargs.get('user_id')),
-            params=kwargs)
+            "/users/{}/meetings".format(kwargs.get("user_id")), params=kwargs
+        )
 
     def create(self, **kwargs):
-        util.require_keys(kwargs, 'user_id')
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, "user_id")
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request(
-            "/users/{}/meetings".format(kwargs.get('user_id')),
-            params=kwargs)
+            "/users/{}/meetings".format(kwargs.get("user_id")), params=kwargs
+        )
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, 'id')
-        return self.get_request(
-            "/meetings/{}".format(kwargs.get('id')),
-            params=kwargs)
+        util.require_keys(kwargs, "id")
+        return self.get_request("/meetings/{}".format(kwargs.get("id")), params=kwargs)
 
     def update(self, **kwargs):
-        util.require_keys(kwargs, 'id')
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, "id")
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.patch_request(
-            "/meetings/{}".format(kwargs.get('id')),
-            params=kwargs)
+            "/meetings/{}".format(kwargs.get("id")), params=kwargs
+        )
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.delete_request(
-            "/meetings/{}".format(kwargs.get('id')),
-            params=kwargs)
+            "/meetings/{}".format(kwargs.get("id")), params=kwargs
+        )

--- a/zoomus/components/recording.py
+++ b/zoomus/components/recording.py
@@ -7,21 +7,21 @@ class RecordingComponent(base.BaseComponent):
     """Component dealing with all recording related matters"""
 
     def list(self, **kwargs):
-        util.require_keys(kwargs, 'host_id')
-        start = kwargs.pop('start', None)
+        util.require_keys(kwargs, "host_id")
+        start = kwargs.pop("start", None)
         if start:
-            kwargs['from'] = util.date_to_str(start)
-        end = kwargs.pop('end', None)
+            kwargs["from"] = util.date_to_str(start)
+        end = kwargs.pop("end", None)
         if end:
-            kwargs['to'] = util.date_to_str(end)
+            kwargs["to"] = util.date_to_str(end)
         return self.post_request("/recording/list", params=kwargs)
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, ['meeting_id'])
+        util.require_keys(kwargs, ["meeting_id"])
         return self.post_request("/recording/delete", params=kwargs)
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, ['meeting_id'])
+        util.require_keys(kwargs, ["meeting_id"])
         return self.post_request("/recording/get", params=kwargs)
 
 
@@ -29,22 +29,25 @@ class RecordingComponentV2(base.BaseComponent):
     """Component dealing with all recording related matters"""
 
     def list(self, **kwargs):
-        util.require_keys(kwargs, 'user_id')
-        start = kwargs.pop('start', None)
+        util.require_keys(kwargs, "user_id")
+        start = kwargs.pop("start", None)
         if start:
-            kwargs['from'] = util.date_to_str(start)
-        end = kwargs.pop('end', None)
+            kwargs["from"] = util.date_to_str(start)
+        end = kwargs.pop("end", None)
         if end:
-            kwargs['to'] = util.date_to_str(end)
+            kwargs["to"] = util.date_to_str(end)
         return self.get_request(
-            "/users/{}/recordings".format(kwargs.get('user_id')), params=kwargs)
+            "/users/{}/recordings".format(kwargs.get("user_id")), params=kwargs
+        )
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, 'meeting_id')
+        util.require_keys(kwargs, "meeting_id")
         return self.get_request(
-            "/meetings/{}/recordings".format(kwargs.get('meeting_id')), params=kwargs)
+            "/meetings/{}/recordings".format(kwargs.get("meeting_id")), params=kwargs
+        )
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, 'meeting_id')
+        util.require_keys(kwargs, "meeting_id")
         return self.delete_request(
-            "/meetings/{}/recordings".format(kwargs.get('meeting_id')), params=kwargs)
+            "/meetings/{}/recordings".format(kwargs.get("meeting_id")), params=kwargs
+        )

--- a/zoomus/components/report.py
+++ b/zoomus/components/report.py
@@ -10,40 +10,37 @@ class ReportComponent(base.BaseComponent):
     """Component dealing with all report related matters"""
 
     def get_account_report(self, **kwargs):
-        util.require_keys(kwargs, ['start_time', 'end_time'], kwargs)
-        kwargs['from'] = util.date_to_str(kwargs['start_time'])
-        del kwargs['start_time']
-        kwargs['to'] = util.date_to_str(kwargs['end_time'])
-        del kwargs['end_time']
+        util.require_keys(kwargs, ["start_time", "end_time"], kwargs)
+        kwargs["from"] = util.date_to_str(kwargs["start_time"])
+        del kwargs["start_time"]
+        kwargs["to"] = util.date_to_str(kwargs["end_time"])
+        del kwargs["end_time"]
         return self.post_request("/report/getaccountreport", params=kwargs)
 
     def get_user_report(self, **kwargs):
-        util.require_keys(kwargs, ['start_time', 'end_time'], kwargs)
-        kwargs['from'] = util.date_to_str(kwargs['start_time'])
-        del kwargs['start_time']
-        kwargs['to'] = util.date_to_str(kwargs['end_time'])
-        del kwargs['end_time']
+        util.require_keys(kwargs, ["start_time", "end_time"], kwargs)
+        kwargs["from"] = util.date_to_str(kwargs["start_time"])
+        del kwargs["start_time"]
+        kwargs["to"] = util.date_to_str(kwargs["end_time"])
+        del kwargs["end_time"]
         return self.post_request("/report/getuserreport", params=kwargs)
 
 
 class ReportComponentV2(base.BaseComponent):
-
     def get_user_report(self, **kwargs):
-        util.require_keys(kwargs, ['user_id', 'start_time', 'end_time'])
-        kwargs['from'] = util.date_to_str(kwargs['start_time'])
-        del kwargs['start_time']
-        kwargs['to'] = util.date_to_str(kwargs['end_time'])
-        del kwargs['end_time']
+        util.require_keys(kwargs, ["user_id", "start_time", "end_time"])
+        kwargs["from"] = util.date_to_str(kwargs["start_time"])
+        del kwargs["start_time"]
+        kwargs["to"] = util.date_to_str(kwargs["end_time"])
+        del kwargs["end_time"]
         return self.get_request(
-            "/report/users/{}/meetings".format(kwargs.get('user_id')),
-            params=kwargs)
+            "/report/users/{}/meetings".format(kwargs.get("user_id")), params=kwargs
+        )
 
     def get_account_report(self, **kwargs):
-        util.require_keys(kwargs, ['start_time', 'end_time'])
-        kwargs['from'] = util.date_to_str(kwargs['start_time'])
-        del kwargs['start_time']
-        kwargs['to'] = util.date_to_str(kwargs['end_time'])
-        del kwargs['end_time']
-        return self.get_request(
-            "/report/users",
-            params=kwargs)
+        util.require_keys(kwargs, ["start_time", "end_time"])
+        kwargs["from"] = util.date_to_str(kwargs["start_time"])
+        del kwargs["start_time"]
+        kwargs["to"] = util.date_to_str(kwargs["end_time"])
+        del kwargs["end_time"]
+        return self.get_request("/report/users", params=kwargs)

--- a/zoomus/components/user.py
+++ b/zoomus/components/user.py
@@ -19,23 +19,23 @@ class UserComponent(base.BaseComponent):
         return self.post_request("/user/create", params=kwargs)
 
     def update(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.post_request("/user/update", params=kwargs)
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.post_request("/user/delete", params=kwargs)
 
     def cust_create(self, **kwargs):
-        util.require_keys(kwargs, ['type', 'email'])
+        util.require_keys(kwargs, ["type", "email"])
         return self.post_request("/user/custcreate", params=kwargs)
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.post_request("/user/get", params=kwargs)
 
     def get_by_email(self, **kwargs):
-        util.require_keys(kwargs, ['email', 'login_type'])
+        util.require_keys(kwargs, ["email", "login_type"])
         return self.post_request("/user/getbyemail", params=kwargs)
 
 
@@ -47,19 +47,13 @@ class UserComponentV2(base.BaseComponent):
         return self.post_request("/users", params=kwargs)
 
     def update(self, **kwargs):
-        util.require_keys(kwargs, 'id')
-        return self.patch_request(
-            "/users/{}".format(kwargs.get('id')),
-            params=kwargs)
+        util.require_keys(kwargs, "id")
+        return self.patch_request("/users/{}".format(kwargs.get("id")), params=kwargs)
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, 'id')
-        return self.delete_request(
-            "/users/{}".format(kwargs.get('id')),
-            params=kwargs)
+        util.require_keys(kwargs, "id")
+        return self.delete_request("/users/{}".format(kwargs.get("id")), params=kwargs)
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, 'id')
-        return self.get_request(
-            "/users/{}".format(kwargs.get('id')),
-            params=kwargs)
+        util.require_keys(kwargs, "id")
+        return self.get_request("/users/{}".format(kwargs.get("id")), params=kwargs)

--- a/zoomus/components/webinar.py
+++ b/zoomus/components/webinar.py
@@ -10,45 +10,45 @@ class WebinarComponent(base.BaseComponent):
     """Component dealing with all webinar related matters"""
 
     def list(self, **kwargs):
-        util.require_keys(kwargs, 'host_id')
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, "host_id")
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/webinar/list", params=kwargs)
 
     def upcoming(self, **kwargs):
-        util.require_keys(kwargs, 'host_id')
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, "host_id")
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/webinar/list/registration", params=kwargs)
 
     def create(self, **kwargs):
-        util.require_keys(kwargs, ['host_id', 'topic'])
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, ["host_id", "topic"])
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/webinar/create", params=kwargs)
 
     def update(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, ["id", "host_id"])
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/webinar/update", params=kwargs)
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
+        util.require_keys(kwargs, ["id", "host_id"])
         return self.post_request("/webinar/delete", params=kwargs)
 
     def end(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
+        util.require_keys(kwargs, ["id", "host_id"])
         return self.post_request("/webinar/end", params=kwargs)
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'host_id'])
+        util.require_keys(kwargs, ["id", "host_id"])
         return self.post_request("/webinar/get", params=kwargs)
 
     def register(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'email', 'first_name', 'last_name'])
-        if kwargs.get('start_time'):
-            kwargs['start_time'] = util.date_to_str(kwargs['start_time'])
+        util.require_keys(kwargs, ["id", "email", "first_name", "last_name"])
+        if kwargs.get("start_time"):
+            kwargs["start_time"] = util.date_to_str(kwargs["start_time"])
         return self.post_request("/webinar/register", params=kwargs)
 
 
@@ -56,43 +56,41 @@ class WebinarComponentV2(base.BaseComponent):
     """Component dealing with all webinar related matters"""
 
     def list(self, **kwargs):
-        util.require_keys(kwargs, 'user_id')
+        util.require_keys(kwargs, "user_id")
         return self.get_request(
-            "/users/{}/webinars".format(kwargs.get('user_id')),
-            params=kwargs)
+            "/users/{}/webinars".format(kwargs.get("user_id")), params=kwargs
+        )
 
     def create(self, **kwargs):
-        util.require_keys(kwargs, 'user_id')
+        util.require_keys(kwargs, "user_id")
         return self.post_request(
-            "/users/{}/webinars".format(kwargs.get('user_id')),
-            params=kwargs)
+            "/users/{}/webinars".format(kwargs.get("user_id")), params=kwargs
+        )
 
     def update(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.patch_request(
-            "/webinars/{}".format(kwargs.get('id')),
-            params=kwargs)
+            "/webinars/{}".format(kwargs.get("id")), params=kwargs
+        )
 
     def delete(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.delete_request(
-            "/webinars/{}".format(kwargs.get('id')),
-            params=kwargs)
+            "/webinars/{}".format(kwargs.get("id")), params=kwargs
+        )
 
     def end(self, **kwargs):
-        util.require_keys(kwargs, 'id')
+        util.require_keys(kwargs, "id")
         return self.put_request(
-            "/webinars/{}/status".format(kwargs.get('id')),
-            params={'status': 'end'})
+            "/webinars/{}/status".format(kwargs.get("id")), params={"status": "end"}
+        )
 
     def get(self, **kwargs):
-        util.require_keys(kwargs, 'id')
-        return self.get_request(
-            "/webinars/{}".format(kwargs.get('id')),
-            params=kwargs)
+        util.require_keys(kwargs, "id")
+        return self.get_request("/webinars/{}".format(kwargs.get("id")), params=kwargs)
 
     def register(self, **kwargs):
-        util.require_keys(kwargs, ['id', 'email', 'first_name', 'last_name'])
+        util.require_keys(kwargs, ["id", "email", "first_name", "last_name"])
         return self.post_request(
-            "/webinars/{}/registrants".format(kwargs.get('id')),
-            params=kwargs)
+            "/webinars/{}/registrants".format(kwargs.get("id")), params=kwargs
+        )

--- a/zoomus/util.py
+++ b/zoomus/util.py
@@ -76,16 +76,15 @@ class ApiClient(object):
         :param headers: request headers
         :return: The :class:``requests.Response`` object for this request
         """
-        if headers is None and self.config.get('version') == API_VERSION_2:
-            headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
+        if headers is None and self.config.get("version") == API_VERSION_2:
+            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
         return requests.get(
-            self.url_for(endpoint),
-            params=params,
-            headers=headers,
-            timeout=self.timeout)
+            self.url_for(endpoint), params=params, headers=headers, timeout=self.timeout
+        )
 
     def post_request(
-            self, endpoint, params=None, data=None, headers=None, cookies=None):
+        self, endpoint, params=None, data=None, headers=None, cookies=None
+    ):
         """Helper function for POST requests
 
         :param endpoint: The endpoint
@@ -98,18 +97,20 @@ class ApiClient(object):
         """
         if data and not is_str_type(data):
             data = json.dumps(data)
-        if headers is None and self.config.get('version') == API_VERSION_2:
-            headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
+        if headers is None and self.config.get("version") == API_VERSION_2:
+            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
         return requests.post(
             self.url_for(endpoint),
             params=params,
             data=data,
             headers=headers,
             cookies=cookies,
-            timeout=self.timeout)
+            timeout=self.timeout,
+        )
 
     def patch_request(
-            self, endpoint, params=None, data=None, headers=None, cookies=None):
+        self, endpoint, params=None, data=None, headers=None, cookies=None
+    ):
         """Helper function for PATCH requests
 
         :param endpoint: The endpoint
@@ -122,18 +123,20 @@ class ApiClient(object):
         """
         if data and not is_str_type(data):
             data = json.dumps(data)
-        if headers is None and self.config.get('version') == API_VERSION_2:
-            headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
+        if headers is None and self.config.get("version") == API_VERSION_2:
+            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
         return requests.patch(
             self.url_for(endpoint),
             params=params,
             data=data,
             headers=headers,
             cookies=cookies,
-            timeout=self.timeout)
+            timeout=self.timeout,
+        )
 
     def delete_request(
-            self, endpoint, params=None, data=None, headers=None, cookies=None):
+        self, endpoint, params=None, data=None, headers=None, cookies=None
+    ):
         """Helper function for DELETE requests
 
         :param endpoint: The endpoint
@@ -146,18 +149,18 @@ class ApiClient(object):
         """
         if data and not is_str_type(data):
             data = json.dumps(data)
-        if headers is None and self.config.get('version') == API_VERSION_2:
-            headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
+        if headers is None and self.config.get("version") == API_VERSION_2:
+            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
         return requests.delete(
             self.url_for(endpoint),
             params=params,
             data=data,
             headers=headers,
             cookies=cookies,
-            timeout=self.timeout)
+            timeout=self.timeout,
+        )
 
-    def put_request(
-            self, endpoint, params=None, data=None, headers=None, cookies=None):
+    def put_request(self, endpoint, params=None, data=None, headers=None, cookies=None):
         """Helper function for PUT requests
 
         :param endpoint: The endpoint
@@ -170,15 +173,16 @@ class ApiClient(object):
         """
         if data and not is_str_type(data):
             data = json.dumps(data)
-        if headers is None and self.config.get('version') == API_VERSION_2:
-            headers = {'Authorization': 'Bearer {}'.format(self.config.get('token'))}
+        if headers is None and self.config.get("version") == API_VERSION_2:
+            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
         return requests.put(
             self.url_for(endpoint),
             params=params,
             data=data,
             headers=headers,
             cookies=cookies,
-            timeout=self.timeout)
+            timeout=self.timeout,
+        )
 
 
 @contextlib.contextmanager
@@ -242,15 +246,9 @@ def date_to_str(d):
 
 
 def generate_jwt(key, secret):
-    header = {
-        "alg": "HS256",
-        "typ": "JWT"
-    }
+    header = {"alg": "HS256", "typ": "JWT"}
 
-    payload = {
-        "iss": key,
-        "exp": int(time.time() + 3600)
-    }
+    payload = {"iss": key, "exp": int(time.time() + 3600)}
 
-    token = jwt.encode(payload, secret, algorithm='HS256', headers=header)
-    return token.decode('utf-8')
+    token = jwt.encode(payload, secret, algorithm="HS256", headers=header)
+    return token.decode("utf-8")


### PR DESCRIPTION
Fixes #16 

This is truly a pretty massive PR, which is unavoidable with a change like this. And unfortunately I snuck a few other improvements into this. What I would recommend is looking at individual commits as opposed to the entire commit history as once.

To sum up what I've done here:
* All code has been reformatted using `black` and its default settings
* Since I added a `pyproject.toml`, I also configured the [PEP 518](https://www.python.org/dev/peps/pep-0518/) isolated build.
* I split the `Contributing` section of the `README.md` out into its own `CONTRIBUTING.md` document, fleshed it out some more, and updated it to more accurately fit the current environment.
* I did a bit of general cleanup in the `README.md`; mostly, made the markup styles for headings consistent.
* I added and documented the `pre-commit` tool, which will help ensure code matches the style enforced by `black`.
* I added a few more badges to the README. Because I'm a sucker for badges. 😄 